### PR TITLE
Add `aggregate_single` to `Aggregator` trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ let mut tree = Tree::<TestAggregator, HEIGHT, ARITY>::new();
 // No elements have been inserted so the root is `None`.
 assert!(matches!(tree.root(), None));
 
-tree.insert(4, [&21u8]);
-tree.insert(7, [&21u8]);
+tree.insert(4, 21);
+tree.insert(7, 21);
 
 // After elements have been inserted, there will be a root.
 assert!(matches!(tree.root(), Some(root) if *root == 42));

--- a/examples/annotation.rs
+++ b/examples/annotation.rs
@@ -114,10 +114,8 @@ fn main() {
 
         let block_height = rng.next_u64() % 1000;
 
-        let annotation = Annotation::from((note, block_height));
         let pos = rng.next_u64() % tree.capacity();
-
-        tree.insert(pos, [&annotation]);
+        tree.insert(pos, (note, block_height));
     }
 
     let elapsed = now.elapsed();

--- a/src/opening.rs
+++ b/src/opening.rs
@@ -56,7 +56,23 @@ impl<A: Aggregator, const HEIGHT: usize, const ARITY: usize>
 
     /// Verify the given item is the leaf of the opening, and that the opening
     /// is cryptographically correct.
-    pub fn verify<'a, I>(&self, items: I) -> bool
+    ///
+    /// Use [`Opening::verify_multiple`] to verify that multiple items are the
+    /// leaf of the opening.
+    pub fn verify<I>(&self, item: I) -> bool
+    where
+        A::Item: PartialEq,
+        I: Into<A::Item>,
+    {
+        self.verify_multiple(&[item.into()])
+    }
+
+    /// Verify the given items are the leaf of the opening, and that the opening
+    /// is cryptographically correct.
+    ///
+    /// Use [`Opening::verify`] to verify that a single item is the leaf of the
+    /// opening.
+    pub fn verify_multiple<'a, I>(&self, items: I) -> bool
     where
         A::Item: 'a + PartialEq,
         I: IntoIterator<Item = &'a A::Item>,
@@ -178,7 +194,7 @@ mod tests {
         let cap = tree.capacity();
 
         for i in 0..cap {
-            tree.insert(i, [&String::from(LETTERS[i as usize])]);
+            tree.insert(i, LETTERS[i as usize]);
         }
 
         for pos in 0..cap {
@@ -187,12 +203,12 @@ mod tests {
                 .expect("There must be an opening for an existing item");
 
             assert!(
-                opening.verify([&String::from(LETTERS[pos as usize])]),
+                opening.verify(LETTERS[pos as usize]),
                 "The opening should be for the item that was inserted at the given position"
             );
 
             assert!(
-                !opening.verify([&String::from(LETTERS[((pos + 1)%cap) as usize])]),
+                !opening.verify(LETTERS[((pos + 1)%cap) as usize]),
                 "The opening should *only* be for the item that was inserted at the given position"
             );
         }


### PR DESCRIPTION
This allows for functions `Tree::insert_multiple` and `Opening::verify_multiple` to be created - which take multiple items as was the previous implementation. In turn, this allows for modifying `Tree::verify` and `Opening::verify` to take `Into<A::Item>`, significantly simplifying the API for downstream use.