### PR TITLE
Add `Aggregate` impl for `blake3::Hash`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --features=rkyv-impl,size_32
+          args: --features=blake3,rkyv-impl,size_32
 
   fmt:
     name: Rustfmt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `blake3` feature, implementing `Aggregate` for `blake3::Hash` [#11]
+
 <!-- ISSUES -->
+[#11]: https://github.com/dusk-network/merkle/issues/11
 
 <!-- VERSIONS -->
 [Unreleased]: https://github.com/dusk-network/merkle/compare/v0.1.0...HEAD

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ license = "MPL-2.0"
 [dependencies]
 rkyv = { version = "0.7", optional = true, default-features = false }
 bytecheck = { version = "0.7", optional = true, default-features = false }
+blake3 = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
 blake3 = "1"

--- a/src/aggregate.rs
+++ b/src/aggregate.rs
@@ -1,0 +1,39 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+/// A type that can be produced by aggregating multiple instances of itself, at
+/// certain heights of the tree.
+#[allow(clippy::module_name_repetitions)]
+pub trait Aggregate {
+    /// Aggregate `items` to produce a single one at the given `height`.
+    fn aggregate<'a, I>(height: usize, items: I) -> Self
+    where
+        Self: 'a,
+        I: ExactSizeIterator<Item = Option<&'a Self>>;
+}
+
+#[cfg(feature = "blake3")]
+mod blake {
+    use super::Aggregate;
+    use blake3::{Hash, Hasher};
+
+    impl Aggregate for Hash {
+        fn aggregate<'a, I>(_: usize, items: I) -> Self
+        where
+            Self: 'a,
+            I: ExactSizeIterator<Item = Option<&'a Self>>,
+        {
+            let mut hasher = Hasher::new();
+            for item in items {
+                match item {
+                    Some(item) => hasher.update(item.as_bytes()),
+                    None => hasher.update(&[0u8; 32]),
+                };
+            }
+            hasher.finalize()
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 #![no_std]
 #![deny(clippy::pedantic)]
 
+mod aggregate;
 mod opening;
 
 extern crate alloc;
@@ -22,17 +23,8 @@ use bytecheck::CheckBytes;
 #[cfg(feature = "rkyv-impl")]
 use rkyv::{ser::Serializer, Archive, Deserialize, Serialize};
 
+pub use aggregate::*;
 pub use opening::*;
-
-/// A type that can be produced by aggregating multiple instances of itself, at
-/// certain heights of the tree.
-pub trait Aggregate {
-    /// Aggregate `items` to produce a single one at the given `height`.
-    fn aggregate<'a, I>(height: usize, items: I) -> Self
-    where
-        Self: 'a,
-        I: ExactSizeIterator<Item = Option<&'a Self>>;
-}
 
 #[cfg_attr(
     feature = "rkyv-impl",


### PR DESCRIPTION
This is behind the `blake3` feature gate, such that the crate is only required when the feature itself is explicitly required.

Resolves #11 