### PR TITLE
Fix `CheckBytes` derivation in `Node`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Derive `Debug`, `Clone`, `PartialEq`, `Eq`, and `Hash` for `Tree` and `Opening` [#13]
 - Add `blake3` feature, implementing `Aggregate` for `blake3::Hash` [#11]
 
+### Fixed
+
+- Fix `CheckBytes` derivation in `Node` [#15]
+
 <!-- ISSUES -->
+[#15]: https://github.com/dusk-network/merkle/issues/15
 [#13]: https://github.com/dusk-network/merkle/issues/13
 [#11]: https://github.com/dusk-network/merkle/issues/11
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "MPL-2.0"
 
 [dependencies]
 rkyv = { version = "0.7", optional = true, default-features = false }
-bytecheck = { version = "0.7", optional = true, default-features = false }
+bytecheck = { version = "0.6", optional = true, default-features = false }
 blake3 = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
@@ -24,6 +24,7 @@ size_16 = ["rkyv/size_16"]
 size_32 = ["rkyv/size_32"]
 size_64 = ["rkyv/size_64"]
 rkyv-impl = [
+    "rkyv/validation",
     "rkyv/alloc",
     "rkyv",
     "bytecheck"


### PR DESCRIPTION
This is required to be able to validate a `Tree` when archived to disk.

Resolves #15