### PR TITLE
(Re)Introduce null item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix `CheckBytes` derivation in `Node` [#15]
 
+### Removed
+
+- Remove `len` field from the `Tree` structure
+
 <!-- ISSUES -->
 [#15]: https://github.com/dusk-network/merkle/issues/15
 [#13]: https://github.com/dusk-network/merkle/issues/13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `Aggregate::NULL` associated constant
 - Derive `Debug`, `Clone`, `PartialEq`, `Eq`, and `Hash` for `Tree` and `Opening` [#13]
 - Add `blake3` feature, implementing `Aggregate` for `blake3::Hash` [#11]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Derive `Debug`, `Clone`, `PartialEq`, `Eq`, and `Hash` for `Tree` and `Opening` [#13]
 - Add `blake3` feature, implementing `Aggregate` for `blake3::Hash` [#11]
 
+### Changed
+
+- Change `Tree::root` to return `&T` instead of `Option<&T>`
+
 ### Fixed
 
 - Fix `CheckBytes` derivation in `Node` [#15]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,7 @@ rkyv-impl = [
     "bytecheck"
 ]
 bench = []
+
+[patch.crates-io.blake3]
+git = "https://github.com/ureeves/BLAKE3"
+branch = "const-conversions"

--- a/README.md
+++ b/README.md
@@ -40,14 +40,14 @@ const A: usize = 2;
 
 let mut tree = Tree::<U8, H, A>::new();
 
-// No elements have been inserted so the root is `None`.
-assert_eq!(tree.root(), None);
+// No elements have been inserted so the root is U8::NULL.
+assert_eq!(tree.root(), &U8::NULL);
 
 tree.insert(4, 21);
 tree.insert(7, 21);
 
 // After elements have been inserted, the root will be `Some`.
-assert!(matches!(tree.root(), Some(n) if n == &U8(42)));
+assert_eq!(tree.root(), &U8(42));
 ```
 
 ## Benchmarks

--- a/README.md
+++ b/README.md
@@ -23,15 +23,14 @@ impl From<u8> for U8 {
 }
 
 impl Aggregate for U8 {
-    fn aggregate<'a, I>(_: usize, items: I) -> Self
+    const NULL: Self = Self(0);
+    
+    fn aggregate<'a, I>(items: I) -> Self
         where
             Self: 'a,
-            I: ExactSizeIterator<Item = Option<&'a Self>>,
+            I: ExactSizeIterator<Item = &'a Self>,
     {
-        items.into_iter().fold(U8(0), |acc, n| match n {
-            Some(n) => U8(acc.0 + n.0),
-            None => acc,
-        })
+        items.into_iter().fold(U8(0), |acc, n| U8(acc.0 + n.0))
     }
 }
 

--- a/examples/annotation.rs
+++ b/examples/annotation.rs
@@ -23,16 +23,20 @@ struct Annotation {
 }
 
 impl Aggregate for Annotation {
-    fn aggregate<'a, I>(_: usize, items: I) -> Self
+    const NULL: Self = Self {
+        hash: Hash::from_bytes([0u8; 32]),
+        bh_range: None,
+    };
+
+    fn aggregate<'a, I>(items: I) -> Self
     where
         Self: 'a,
-        I: ExactSizeIterator<Item = Option<&'a Self>>,
+        I: ExactSizeIterator<Item = &'a Self>,
     {
         let mut hasher = Hasher::new();
         let mut bh_range = None;
 
-        // TODO don't use `flatten` and use a "zero item" instead?
-        for item in items.flatten() {
+        for item in items {
             hasher.update(item.hash.as_bytes());
 
             bh_range = match (bh_range, item.bh_range.as_ref()) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,7 +169,6 @@ const fn capacity(arity: u64, depth: usize) -> u64 {
 pub struct Tree<T, const H: usize, const A: usize> {
     root: Node<T, H, A>,
     positions: BTreeSet<u64>,
-    len: u64,
 }
 
 impl<T: Aggregate, const H: usize, const A: usize> Tree<T, H, A> {
@@ -179,7 +178,6 @@ impl<T: Aggregate, const H: usize, const A: usize> Tree<T, H, A> {
         Self {
             root: Node::new(T::NULL),
             positions: BTreeSet::new(),
-            len: 0,
         }
     }
 
@@ -189,27 +187,20 @@ impl<T: Aggregate, const H: usize, const A: usize> Tree<T, H, A> {
     /// If `position >= capacity`.
     pub fn insert(&mut self, position: u64, item: impl Into<T>) {
         self.root.insert(0, position, item);
-        if self.positions.insert(position) {
-            self.len += 1;
-        }
+        self.positions.insert(position);
     }
 
     /// Remove and return the item at the given `position` in the tree if it
     /// exists.
-    // Allowing for missing docs on panic, since panic is impossible. See
-    // comment below.
-    #[allow(clippy::missing_panics_doc)]
     pub fn remove(&mut self, position: u64) -> Option<T> {
         if !self.positions.contains(&position) {
             return None;
         }
 
         let (item, _) = self.root.remove(0, position);
-
-        self.len -= 1;
         self.positions.remove(&position);
 
-        if self.len == 0 {
+        if self.positions.is_empty() {
             self.root.item = T::NULL;
         }
 
@@ -242,7 +233,7 @@ impl<T: Aggregate, const H: usize, const A: usize> Tree<T, H, A> {
     /// Returns the number of elements that have been inserted into the tree.
     #[must_use]
     pub fn len(&self) -> u64 {
-        self.len
+        self.positions.len() as u64
     }
 
     /// Returns `true` if the tree is empty.

--- a/src/opening.rs
+++ b/src/opening.rs
@@ -36,9 +36,7 @@ impl<T: Aggregate, const H: usize, const A: usize> Opening<T, H, A> {
     {
         let positions = [0; H];
         let branch = zero_array(|_| zero_array(|_| None));
-        let root = tree.root.as_ref().expect(
-            "The tree should have a root since it has a position filled",
-        );
+        let root = &tree.root;
 
         let mut opening = Self {
             root: root.item.clone(),

--- a/src/opening.rs
+++ b/src/opening.rs
@@ -66,7 +66,13 @@ impl<T: Aggregate, const H: usize, const A: usize> Opening<T, H, A> {
                 return false;
             }
 
-            item = T::aggregate(h, self.branch[h].iter().map(Option::as_ref));
+            let null = T::NULL;
+
+            item = T::aggregate(
+                self.branch[h]
+                    .iter()
+                    .map(|item| item.as_ref().unwrap_or(&null)),
+            );
         }
 
         self.root == item
@@ -133,15 +139,14 @@ mod tests {
 
     /// A simple aggregator that concatenates strings.
     impl Aggregate for String {
-        fn aggregate<'a, I>(_: usize, items: I) -> Self
+        const NULL: Self = String::new();
+
+        fn aggregate<'a, I>(items: I) -> Self
         where
             Self: 'a,
-            I: ExactSizeIterator<Item = Option<&'a Self>>,
+            I: ExactSizeIterator<Item = &'a Self>,
         {
-            items.into_iter().fold(String::new(), |acc, s| match s {
-                Some(s) => acc + s,
-                None => acc,
-            })
+            items.into_iter().fold(Self::NULL, |acc, s| acc + s)
         }
     }
 


### PR DESCRIPTION
Change the `Aggregate` trait to include an associated constant called `NULL`. It allows the implementer to provide an item to be used in place of `None` when a sub-tree is empty. Height is also no longer provided in `Aggregate::aggregate` - since its purpose was mainly to allow the user to use a "null item" anyway.

This change allows us to change the return of `root` as well, since the root item can now always be set to the `NULL` item.