### PR TITLE
(Re)introduce multiple null items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Derive `Debug`, `Clone`, `PartialEq`, `Eq`, and `Hash` for `Tree` and `Opening` [#13]
 - Add `blake3` feature, implementing `Aggregate` for `blake3::Hash` [#11]
 
+### Changed
+
+- Change `Tree` structure by removing `len` field
+
 ### Fixed
 
 - Fix `CheckBytes` derivation in `Node` [#15]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Change `Aggregate` trait to bind `Self` to be `Copy`
+- Change `Tree::root` to return `&T` as opposed to `Option<&T>`
 - Change `Tree` structure by removing `len` field
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `EMPTY_SUBTREES` to `Aggregate` trait
 - Derive `Debug`, `Clone`, `PartialEq`, `Eq`, and `Hash` for `Tree` and `Opening` [#13]
-- Add `blake3` feature, implementing `Aggregate` for `blake3::Hash` [#11]
 
 ### Changed
 
@@ -26,7 +25,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- ISSUES -->
 [#15]: https://github.com/dusk-network/merkle/issues/15
 [#13]: https://github.com/dusk-network/merkle/issues/13
-[#11]: https://github.com/dusk-network/merkle/issues/11
 
 <!-- VERSIONS -->
 [Unreleased]: https://github.com/dusk-network/merkle/compare/v0.1.0...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `EMPTY_SUBTREES` to `Aggregate` trait
 - Derive `Debug`, `Clone`, `PartialEq`, `Eq`, and `Hash` for `Tree` and `Opening` [#13]
 - Add `blake3` feature, implementing `Aggregate` for `blake3::Hash` [#11]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,6 @@ rkyv-impl = [
     "bytecheck"
 ]
 bench = []
+
+[patch.crates-io]
+blake3 = { git = "https://github.com/ureeves/BLAKE3", branch = "const-conversions" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,3 @@ rkyv-impl = [
     "bytecheck"
 ]
 bench = []
-
-[patch.crates-io]
-blake3 = { git = "https://github.com/ureeves/BLAKE3", branch = "const-conversions" }

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Height 2  o   x x   x
 ```rust
 use dusk_merkle::{Tree, Aggregate};
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 struct U8(u8);
 
 impl From<u8> for U8 {
@@ -22,16 +22,17 @@ impl From<u8> for U8 {
     }
 }
 
-impl Aggregate for U8 {
-    fn aggregate<'a, I>(_: usize, items: I) -> Self
+const EMPTY_ITEM: U8 = U8(0);
+
+impl Aggregate<H, A> for U8 {
+    const EMPTY_SUBTREES: [U8; H] = [EMPTY_ITEM; H];
+    
+    fn aggregate<'a, I>(items: I) -> Self
         where
             Self: 'a,
-            I: ExactSizeIterator<Item = Option<&'a Self>>,
+            I: Iterator<Item = &'a Self>,
     {
-        items.into_iter().fold(U8(0), |acc, n| match n {
-            Some(n) => U8(acc.0 + n.0),
-            None => acc,
-        })
+        items.into_iter().fold(U8(0), |acc, n| U8(acc.0 + n.0))
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Height 2  o   x x   x
 ```rust
 use dusk_merkle::{Tree, Aggregate};
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 struct U8(u8);
 
 impl From<u8> for U8 {
@@ -42,14 +42,14 @@ const A: usize = 2;
 
 let mut tree = Tree::<U8, H, A>::new();
 
-// No elements have been inserted so the root is `None`.
-assert_eq!(tree.root(), None);
+// No elements have been inserted so the root is the first empty item.
+assert_eq!(tree.root(), &U8::EMPTY_SUBTREES[0]);
 
 tree.insert(4, 21);
 tree.insert(7, 21);
 
-// After elements have been inserted, the root will be `Some`.
-assert!(matches!(tree.root(), Some(n) if n == &U8(42)));
+// After elements have been inserted, the root will be modified.
+assert_eq!(tree.root(), &U8(42));
 ```
 
 ## Benchmarks

--- a/src/aggregate.rs
+++ b/src/aggregate.rs
@@ -6,7 +6,7 @@
 
 /// A type that can be produced by aggregating multiple instances of itself, at
 /// certain heights of the tree.
-pub trait Aggregate<const H: usize, const A: usize>: Clone {
+pub trait Aggregate<const H: usize, const A: usize>: Copy {
     /// The items to be used for a given empty subtree at the given height.
     const EMPTY_SUBTREES: [Self; H];
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,10 +55,9 @@ pub struct Node<T, const H: usize, const A: usize> {
 
 impl<T, const H: usize, const A: usize> Node<T, H, A>
 where
-    T: Aggregate,
+    T: Aggregate<H, A>,
 {
     const INIT_NODE: Option<Box<Node<T, H, A>>> = None;
-    const INIT_ITEM: Option<T> = None;
 
     const fn new(item: T) -> Self {
         debug_assert!(H > 0, "Height must be larger than zero");
@@ -71,11 +70,13 @@ where
     }
 
     fn compute_item(&mut self, height: usize) {
+        let empty = &T::EMPTY_SUBTREES[height];
+
         self.item = T::aggregate(
-            height,
             self.children
                 .iter()
-                .map(|node| node.as_ref().map(|node| &node.item)),
+                .map(|node| node.as_ref().map(|node| &node.as_ref().item))
+                .map(|item| item.unwrap_or(empty)),
         );
     }
 
@@ -101,10 +102,8 @@ where
 
         let child = &mut self.children[child_index];
         if child.is_none() {
-            *child = Some(Box::new(Node::new(T::aggregate(
-                height,
-                [Self::INIT_ITEM; A].iter().map(Option::as_ref),
-            ))));
+            *child =
+                Some(Box::new(Node::new(T::EMPTY_SUBTREES[height].clone())));
         }
 
         // We just inserted a child at the given index.
@@ -121,10 +120,7 @@ where
     /// If an element does not exist at the given position.
     fn remove(&mut self, height: usize, position: u64) -> (T, bool) {
         if height == H {
-            let mut item = T::aggregate(
-                height,
-                [Self::INIT_ITEM; A].iter().map(Option::as_ref),
-            );
+            let mut item = T::EMPTY_SUBTREES[0].clone();
             mem::swap(&mut self.item, &mut item);
             return (item, false);
         }
@@ -178,9 +174,10 @@ pub struct Tree<T, const H: usize, const A: usize> {
     len: u64,
 }
 
-impl<T: Aggregate, const H: usize, const A: usize> Tree<T, H, A> {
-    const INIT_ITEM: Option<T> = None;
-
+impl<T, const H: usize, const A: usize> Tree<T, H, A>
+where
+    T: Aggregate<H, A>,
+{
     /// Create a new merkle tree with the given initial `root`.
     #[must_use]
     pub const fn new() -> Self {
@@ -197,10 +194,7 @@ impl<T: Aggregate, const H: usize, const A: usize> Tree<T, H, A> {
     /// If `position >= capacity`.
     pub fn insert(&mut self, position: u64, item: impl Into<T>) {
         if self.root.is_none() {
-            self.root = Some(Node::new(T::aggregate(
-                0,
-                [Self::INIT_ITEM; A].iter().map(Option::as_ref),
-            )));
+            self.root = Some(Node::new(T::EMPTY_SUBTREES[0].clone()));
         }
 
         // We just inserted a root node so we can unwrap.
@@ -283,16 +277,15 @@ impl<T: Aggregate, const H: usize, const A: usize> Tree<T, H, A> {
 mod tests {
     use super::*;
 
-    impl Aggregate for u8 {
-        fn aggregate<'a, I>(_: usize, items: I) -> Self
+    impl Aggregate<H, A> for u8 {
+        const EMPTY_SUBTREES: [Self; H] = [0; H];
+
+        fn aggregate<'a, I>(items: I) -> Self
         where
             Self: 'a,
-            I: ExactSizeIterator<Item = Option<&'a Self>>,
+            I: Iterator<Item = &'a Self>,
         {
-            items.into_iter().fold(0, |acc, n| match n {
-                Some(n) => acc + n,
-                None => acc,
-            })
+            items.into_iter().sum()
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,7 +171,6 @@ const fn capacity(arity: u64, depth: usize) -> u64 {
 pub struct Tree<T, const H: usize, const A: usize> {
     root: Option<Node<T, H, A>>,
     positions: BTreeSet<u64>,
-    len: u64,
 }
 
 impl<T, const H: usize, const A: usize> Tree<T, H, A>
@@ -184,7 +183,6 @@ where
         Self {
             root: None,
             positions: BTreeSet::new(),
-            len: 0,
         }
     }
 
@@ -201,9 +199,7 @@ where
         let root = self.root.as_mut().unwrap();
 
         root.insert(0, position, item);
-        if self.positions.insert(position) {
-            self.len += 1;
-        }
+        self.positions.insert(position);
     }
 
     /// Remove and return the item at the given `position` in the tree if it
@@ -221,10 +217,8 @@ where
 
         let (item, _) = root.remove(0, position);
 
-        self.len -= 1;
         self.positions.remove(&position);
-
-        if self.len == 0 {
+        if self.positions.is_empty() {
             self.root = None;
         }
 
@@ -257,7 +251,7 @@ where
     /// Returns the number of elements that have been inserted into the tree.
     #[must_use]
     pub fn len(&self) -> u64 {
-        self.len
+        self.positions.len() as u64
     }
 
     /// Returns `true` if the tree is empty.


### PR DESCRIPTION
Change the `Aggregate` trait to include an associated constant called `EMPTY_SUBTREES`. It allows the implementer to provide multiple items to be used in place of `None` when a sub-tree is empty. Height is also no longer provided in `Aggregate::aggregate` - since its purpose was mainly to allow the user to use a "null item" anyway.

This change allows us to change the return of `root` as well, since the root item can now always be set to the first empty item.