### PR TITLE
Release `0.1.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0] - 2023-04-26
+
 ### Added
 
 - Add `Tree::walk` allowing a user to walk the tree [#21]


### PR DESCRIPTION
## [0.1.0] - 2023-04-26

### Added

- Add `Tree::walk` allowing a user to walk the tree [#21]
- Add example of generating zero hashes for `blake3`
- Add `EMPTY_SUBTREES` to `Aggregate` trait
- Derive `Debug`, `Clone`, `PartialEq`, `Eq`, and `Hash` for `Tree` and `Opening` [#13]

### Changed

- Change `Aggregate` trait to bind `Self` to be `Copy`
- Change `Tree::root` to return `&T` as opposed to `Option<&T>`
- Change `Tree` structure by removing `len` field

### Fixed

- Fix `CheckBytes` derivation in `Node` [#15]

[0.1.0]: https://github.com/dusk-network/merkle/releases/tag/v0.1.0
