### PR TITLE
Prepare `Opening` to be used outside the crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add getters for all fields in `Opening` [#25]
+
 ### Changed
 
-- Change opening branch to hold `T` instead of `Option<T>`
+- Change opening branch to hold `T` instead of `Option<T>` [#25]
 
 ## [0.1.0] - 2023-04-26
 
@@ -31,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix `CheckBytes` derivation in `Node` [#15]
 
 <!-- ISSUES -->
+[#25]: https://github.com/dusk-network/merkle/issues/25
 [#21]: https://github.com/dusk-network/merkle/issues/21
 [#15]: https://github.com/dusk-network/merkle/issues/15
 [#13]: https://github.com/dusk-network/merkle/issues/13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Change opening branch to hold `T` instead of `Option<T>`
+
 ## [0.1.0] - 2023-04-26
 
 ### Added

--- a/src/opening.rs
+++ b/src/opening.rs
@@ -47,6 +47,21 @@ where
         opening
     }
 
+    /// Returns the root of the opening.
+    pub fn root(&self) -> &T {
+        &self.root
+    }
+
+    /// Returns the branch of the opening.
+    pub fn branch(&self) -> &[[T; A]; H] {
+        &self.branch
+    }
+
+    /// Returns the indices for the path in the opening.
+    pub fn positions(&self) -> &[usize; H] {
+        &self.positions
+    }
+
     /// Verify the given item is the leaf of the opening, and that the opening
     /// is cryptographically correct.
     pub fn verify(&self, item: impl Into<T>) -> bool


### PR DESCRIPTION
This also changes the branch from `Option<T>` to `T`