### PR TITLE
Release `0.2.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2023-05-17
+
 ### Added
 
 - Add getters for all fields in `Opening` [#25]
@@ -43,5 +45,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#13]: https://github.com/dusk-network/merkle/issues/13
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/merkle/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/dusk-network/merkle/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/dusk-network/merkle/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/dusk-network/merkle/releases/tag/v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dusk-merkle"
 description = "Crate implementing Dusk Network's Merkle tree"
-version = "0.1.0"
+version = "0.2.0"
 
 categories = ["data-structures", "no-std"]
 keywords = ["tree", "merkle", "hash", "data", "structure"]


### PR DESCRIPTION
## [0.2.0] - 2023-05-17

### Added

- Add getters for all fields in `Opening` [#25]
- Add merkle tree implementation with poseidon hash and opening gadget [#29]

### Changed

- Change opening branch to hold `T` instead of `Option<T>` [#25]

[0.2.0]: https://github.com/dusk-network/merkle/compare/v0.1.0...v0.2.0