### PR TITLE
Add lazy computation of node items 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add lazy computation of node items [#37]
+- Add missing Rkyv derivations for poseidon `Item`
+
 ### Changed
 
+- Return `Ref<T>` from `Tree::root` instead of `&T` [#37]
+- `Walk` now binds `T` to be `Aggregate` [#37]
 - Change `Aggregate` trait to provide an array of references instead of an iterator [#44]
 - Change the benchmarks to use criterion [#34]
 
-### Added
+### Removed
 
-- Added missing Rkyv derivations for poseidon `Item`
+- Remove `Hash` derivation on `Tree` [#37]
 
 ## [0.2.0] - 2023-05-17
 
@@ -49,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- ISSUES -->
 [#44]: https://github.com/dusk-network/merkle/issues/44
+[#37]: https://github.com/dusk-network/merkle/issues/37
 [#32]: https://github.com/dusk-network/merkle/issues/32
 [#29]: https://github.com/dusk-network/merkle/issues/29
 [#25]: https://github.com/dusk-network/merkle/issues/25

--- a/README.md
+++ b/README.md
@@ -47,13 +47,13 @@ const A: usize = 2;
 let mut tree = Tree::<U8, H, A>::new();
 
 // No elements have been inserted so the root is the first empty item.
-assert_eq!(tree.root(), &U8::EMPTY_SUBTREES[0]);
+assert_eq!(*tree.root(), U8::EMPTY_SUBTREES[0]);
 
 tree.insert(4, 21);
 tree.insert(7, 21);
 
 // After elements have been inserted, the root will be modified.
-assert_eq!(tree.root(), &U8(42));
+assert_eq!(*tree.root(), U8(42));
 ```
 
 ## Benchmarks

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "stable"
+channel = "nightly"
 components = ["rustfmt", "clippy"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,9 +34,7 @@ pub trait Aggregate<const H: usize, const A: usize>: Copy {
     /// The items to be used for a given empty subtree at the given height.
     const EMPTY_SUBTREES: [Self; H];
 
-    /// Aggregate the given `items` to produce a single one. The given iterator
-    /// is guaranteed to produce `A` number of items, from the leftmost to the
-    /// rightmost child of a tree's node.
+    /// Aggregate the given array of item references to return a single item.
     fn aggregate(items: [&Self; A]) -> Self;
 }
 

--- a/src/opening.rs
+++ b/src/opening.rs
@@ -35,7 +35,7 @@ where
         let branch = init_array(|h| init_array(|_| T::EMPTY_SUBTREES[h]));
 
         let mut opening = Self {
-            root: tree.root.item,
+            root: *tree.root.item(0),
             branch,
             positions,
         };
@@ -77,8 +77,8 @@ where
                 return false;
             }
 
-            let ref_array = init_array(|i| &self.branch[h][i]);
-            item = T::aggregate(ref_array);
+            let item_refs = init_array(|i| &self.branch[h][i]);
+            item = T::aggregate(item_refs);
         }
 
         self.root == item
@@ -107,7 +107,7 @@ fn fill_opening<T, const H: usize, const A: usize>(
 
     for i in 0..A {
         if let Some(child) = &node.children[i] {
-            opening.branch[height][i] = child.item;
+            opening.branch[height][i] = *child.item(height);
         }
     }
     opening.positions[height] = child_index;


### PR DESCRIPTION
- Return `Ref<T>` from `Tree::root` instead of `&T`
- `Walk` now binds `T` to be `Aggregate`
- Remove `Hash` derivation on `Tree`

Resolves: https://github.com/dusk-network/merkle/issues/37