### PR TITLE
Release `0.4.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.4.0] - 2023-06-07
 
 ### Added
 
@@ -81,7 +81,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#13]: https://github.com/dusk-network/merkle/issues/13
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/merkle/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/dusk-network/merkle/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/dusk-network/merkle/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/dusk-network/merkle/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/dusk-network/merkle/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/dusk-network/merkle/releases/tag/v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dusk-merkle"
 description = "Crate implementing Dusk Network's Merkle tree"
-version = "0.3.0"
+version = "0.4.0"
 
 categories = ["data-structures", "no-std"]
 keywords = ["tree", "merkle", "hash", "data", "structure"]


### PR DESCRIPTION
## [0.4.0] - 2023-06-07

### Added

- Documented poseidon related types [#31]

### Changed

- Modify `Aggregate` to include only one `EMPTY_SUBTREE` [#49]
- Relax `Aggregate` bounds to not be `Copy` [#49]
- Change return of `Tree::smallest_subtree` to `Ref<T>` as opposed to `Option<Ref<T>>` [#49]

[0.4.0]: https://github.com/dusk-network/merkle/compare/v0.3.0...v0.4.0