### PR TITLE
Add more comprehensive benchmarks

### DIFF
--- a/benches/blake3.rs
+++ b/benches/blake3.rs
@@ -4,37 +4,74 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 
+use rand::rngs::StdRng;
 use rand::{RngCore, SeedableRng};
 
 use blake3::Hasher;
+
 use dusk_merkle::blake3::Item;
 use dusk_merkle::Tree;
 
 const H: usize = 32;
-const A: usize = 4;
+const A: usize = 2;
 
 type Blake3Tree = Tree<Item, H, A>;
 
-fn bench_blake3(c: &mut Criterion) {
-    let tree = &mut Blake3Tree::new();
-    let rng = &mut rand::rngs::StdRng::seed_from_u64(0xbeef);
+const NS: &[u64] = &[10, 100, 1000, 10000];
 
-    c.bench_function("blake3 insertion", |b| {
-        b.iter(|| {
-            let pos = rng.next_u64();
+fn bench_blake3_insert(c: &mut Criterion) {
+    let rng = &mut StdRng::seed_from_u64(0xbeef);
 
-            let mut hash_bytes = [0u8; 32];
-            rng.fill_bytes(&mut hash_bytes);
-            let mut hasher = Hasher::new();
-            hasher.update(&hash_bytes);
-            let hash: Item = hasher.finalize().into();
-
-            tree.insert(black_box(pos), black_box(hash));
-        })
-    });
+    let mut group = c.benchmark_group("blake3_insert_n");
+    for n in NS {
+        group.bench_with_input(
+            BenchmarkId::from_parameter(*n),
+            n,
+            |b, &size| {
+                b.iter(|| {
+                    let mut tree = Blake3Tree::new();
+                    insert_random_n(rng, &mut tree, size);
+                });
+            },
+        );
+    }
 }
 
-criterion_group!(benches, bench_blake3);
+fn bench_blake3_root(c: &mut Criterion) {
+    let rng = &mut StdRng::seed_from_u64(0xbeef);
+
+    let mut group = c.benchmark_group("blake3_root_n");
+    for n in NS {
+        group.bench_with_input(
+            BenchmarkId::from_parameter(*n),
+            n,
+            |b, &size| {
+                b.iter(|| {
+                    let mut tree = Blake3Tree::new();
+                    insert_random_n(rng, &mut tree, size);
+                    let _root = *tree.root();
+                });
+            },
+        );
+    }
+}
+
+fn insert_random_n<Rng: RngCore>(rng: &mut Rng, tree: &mut Blake3Tree, n: u64) {
+    let cap = tree.capacity();
+
+    let mut hash_bytes = [0u8; 32];
+    rng.fill_bytes(&mut hash_bytes);
+    let mut hasher = Hasher::new();
+    hasher.update(&hash_bytes);
+    let hash: Item = hasher.finalize().into();
+
+    for _ in 0..n {
+        let pos = rng.next_u64() % cap;
+        tree.insert(pos, hash);
+    }
+}
+
+criterion_group!(benches, bench_blake3_insert, bench_blake3_root);
 criterion_main!(benches);


### PR DESCRIPTION
The `blake3` insertion benchmark is rewritten to allow for measuring the time of multiple variable insertions. A new benchmark is also introduced that does the same as the insertion benchmark, but also computes the root of the tree at the end of the insertions.

Both of these benchmarks allow for accurate estimation of the root calculation from scratch, given a certain number of elements inserted.

These are the results on a `AMD Ryzen 9 5950X` (3.4 GHz base clock):
```text
blake3_insert_n/10      time:   [6.5373 µs 6.5423 µs 6.5481 µs]
blake3_insert_n/100     time:   [73.387 µs 73.877 µs 74.377 µs]
blake3_insert_n/1000    time:   [1.1084 ms 1.1090 ms 1.1095 ms]
blake3_insert_n/10000   time:   [12.633 ms 12.789 ms 12.948 ms]

blake3_root_n/10        time:   [31.108 µs 31.271 µs 31.422 µs]
blake3_root_n/100       time:   [298.88 µs 298.93 µs 298.98 µs]
blake3_root_n/1000      time:   [3.0444 ms 3.0616 ms 3.0790 ms]
blake3_root_n/10000     time:   [31.971 ms 32.185 ms 32.420 ms]
```