### PR TITLE
Bump to `0.4.1-rc.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dusk-merkle"
 description = "Crate implementing Dusk Network's Merkle tree"
-version = "0.4.0"
+version = "0.4.1-rc.0"
 
 categories = ["data-structures", "no-std"]
 keywords = ["tree", "merkle", "hash", "data", "structure"]


### PR DESCRIPTION
## Added

- Add more comprehensive benchmarks for `blake3` tree [#54]
- Add `to_var_bytes` and `from_slice` to `Opening` [#55]
