### PR TITLE
Bump to `0.5.0`

### DIFF
--- a/dusk-merkle/CHANGELOG.md
+++ b/dusk-merkle/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2023-06-28
+
 ### Removed
 
 - Remove features `blake3`, `poseidon` and `zk` [#58]
@@ -101,7 +103,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#13]: https://github.com/dusk-network/merkle/issues/13
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/merkle/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/dusk-network/merkle/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/dusk-network/merkle/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/dusk-network/merkle/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/dusk-network/merkle/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/dusk-network/merkle/compare/v0.1.0...v0.2.0

--- a/dusk-merkle/Cargo.toml
+++ b/dusk-merkle/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dusk-merkle"
 description = "Crate implementing Dusk Network's Merkle tree"
-version = "0.4.1-rc.0"
+version = "0.5.0"
 
 categories = ["data-structures", "no-std"]
 keywords = ["tree", "merkle", "hash", "data", "structure"]


### PR DESCRIPTION
## [0.5.0] - 2023-06-28

### Removed

- Remove features `blake3`, `poseidon` and `zk` [#58]
- Remove `Aggregate` implementations for blake3 and poseidon [#58]

### Added

- Add more comprehensive benchmarks for `blake3` tree [#54]
- Add `to_var_bytes` and `from_slice` to `Opening` [#55]

### Changed

- Update to poseidon hash optimized for merkle openings [#62]

[0.5.0]: https://github.com/dusk-network/merkle/compare/v0.4.0...v0.5.0
