### PR TITLE
[poseidon] Bump to v0.2.0

### DIFF
--- a/poseidon-merkle/CHANGELOG.md
+++ b/poseidon-merkle/CHANGELOG.md
@@ -7,9 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-[0.1.0] - 2023-06-28
+## [0.2.0] - 2023-06-28
 
-## Added
+### Changed
+
+- Update `dusk-merkle` to `v0.5.0`
+
+## [0.1.0] - 2023-06-28
+
+### Added
 
 - Add poseidon-merkle crate [#58]
 
@@ -17,5 +23,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#58]: https://github.com/dusk-network/merkle/issues/58
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/merkle/compare/poseidon-merkle_v0.1.0...HEAD
+[Unreleased]: https://github.com/dusk-network/merkle/compare/poseidon-merkle_v0.2.0...HEAD
+[0.2.0]: https://github.com/dusk-network/merkle/compare/poseidon-merkle_v0.1.0...poseidon-merkle_v0.2.0
 [0.1.0]: https://github.com/dusk-network/merkle/releases/tag/poseidon-merkle_v0.1.0

--- a/poseidon-merkle/Cargo.toml
+++ b/poseidon-merkle/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "poseidon-merkle"
 description = "Crate implementing Dusk Network's Merkle tree"
-version = "0.1.0"
+version = "0.2.0"
 
 categories = ["data-structures", "no-std"]
 keywords = ["tree", "merkle", "poseidon", "hash", "data", "structure"]
@@ -15,7 +15,7 @@ edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
-dusk-merkle = "0.4"
+dusk-merkle = "0.5"
 dusk-poseidon = { version = "0.30", default-features = false, features = ["merkle"] }
 dusk-bls12_381 = { version = "0.11", default-features = false }
 dusk-plonk = { version = "0.14", optional = true, default-features = false }


### PR DESCRIPTION
## [0.2.0] - 2023-06-28

### Changed

- Update `dusk-merkle` to `v0.5.0`

[0.2.0]: https://github.com/dusk-network/merkle/compare/poseidon-merkle_v0.1.0...poseidon-merkle_v0.2.0
