### PR TITLE
poseidon: Fix `rkyv-impl` feature, bump to `v0.2.1-rc.0`

### DIFF
--- a/poseidon-merkle/CHANGELOG.md
+++ b/poseidon-merkle/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `rkyv-impl` feature
+
 ## [0.2.0] - 2023-06-28
 
 ### Changed

--- a/poseidon-merkle/Cargo.toml
+++ b/poseidon-merkle/Cargo.toml
@@ -36,7 +36,8 @@ rkyv-impl = [
     "rkyv/alloc",
     "rkyv",
     "bytecheck",
-    "dusk-bls12_381/rkyv-impl"
+    "dusk-bls12_381/rkyv-impl",
+    "dusk-merkle/rkyv-impl"
 ]
 
 [[bench]]

--- a/poseidon-merkle/Cargo.toml
+++ b/poseidon-merkle/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "poseidon-merkle"
 description = "Crate implementing Dusk Network's Merkle tree"
-version = "0.2.0"
+version = "0.2.1-rc.0"
 
 categories = ["data-structures", "no-std"]
 keywords = ["tree", "merkle", "poseidon", "data", "structure"]


### PR DESCRIPTION
Fixed the feature `poseidon-merkle/rkyv-impl`, which didn't cause the activation of `dusk-merkle/rkyv-impl`.

Bump version to `0.2.1-rc.0`
