### PR TITLE
dusk-merkle: fix `rkyv` serialization for `Tree`

### DIFF
--- a/dusk-merkle/CHANGELOG.md
+++ b/dusk-merkle/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `rkyv` serialization for `Tree` [#73]
+
 ## [0.5.1] - 2023-10-12
 
 ### Removed
@@ -96,6 +100,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix `CheckBytes` derivation in `Node` [#15]
 
 <!-- ISSUES -->
+[#73]: https://github.com/dusk-network/merkle/issues/73
 [#62]: https://github.com/dusk-network/merkle/issues/62
 [#58]: https://github.com/dusk-network/merkle/issues/58
 [#55]: https://github.com/dusk-network/merkle/issues/55

--- a/dusk-merkle/src/tree.rs
+++ b/dusk-merkle/src/tree.rs
@@ -323,4 +323,27 @@ mod tests {
         assert!(smallest_subtree.is_none());
         assert_eq!(height, 0);
     }
+
+    #[cfg(feature = "rkyv-impl")]
+    mod rkyv_impl {
+        use super::SumTree;
+
+        #[test]
+        fn serde() {
+            let mut tree = SumTree::new();
+
+            tree.insert(5, 42);
+            tree.insert(6, 42);
+            tree.insert(5, 42);
+
+            let tree_bytes = rkyv::to_bytes::<_, 128>(&tree)
+                .expect("Archiving a tree should succeed")
+                .to_vec();
+
+            let archived_tree = rkyv::from_bytes::<SumTree>(&tree_bytes)
+                .expect("Deserializing a tree should succeed");
+
+            assert_eq!(tree, archived_tree);
+        }
+    }
 }


### PR DESCRIPTION
This is achieved by custom implementations of `Archive`, `Serialize` and `Deserialize` for the `Node` struct, avoiding the internal `RefCell`.

Resolves #73