### PR TITLE
Release `0.5.2`

### DIFF
--- a/dusk-merkle/CHANGELOG.md
+++ b/dusk-merkle/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2] - 2023-10-27
+
 ### Fixed
 
 - Fix `rkyv` serialization for `Tree` [#73]
@@ -118,7 +120,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#13]: https://github.com/dusk-network/merkle/issues/13
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/merkle/compare/v0.5.1...HEAD
+[Unreleased]: https://github.com/dusk-network/merkle/compare/v0.5.2...HEAD
+[0.5.2]: https://github.com/dusk-network/merkle/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/dusk-network/merkle/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/dusk-network/merkle/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/dusk-network/merkle/compare/v0.3.0...v0.4.0

--- a/dusk-merkle/Cargo.toml
+++ b/dusk-merkle/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dusk-merkle"
 description = "Crate implementing Dusk Network's Merkle tree"
-version = "0.5.1"
+version = "0.5.2"
 
 categories = ["data-structures", "no-std"]
 keywords = ["tree", "merkle", "hash", "data", "structure"]


### PR DESCRIPTION
## [dusk-merkle 0.5.2] - 2023-10-27

### Fixed

- Fix `rkyv` serialization for `Tree` [#73]

[dusk-merkle 0.5.2]: https://github.com/dusk-network/merkle/compare/v0.5.1...v0.5.2
