### PR TITLE
poseidon-merkle: Bump to v0.4.0

### DIFF
--- a/poseidon-merkle/CHANGELOG.md
+++ b/poseidon-merkle/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2023-12-13
+
 ### Changed
 
 - Update `dusk-bls12_381` to 0.13
@@ -43,7 +45,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#58]: https://github.com/dusk-network/merkle/issues/58
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/merkle/compare/poseidon-merkle_v0.3.0...HEAD
+[Unreleased]: https://github.com/dusk-network/merkle/compare/poseidon-merkle_v0.4.0...HEAD
+[0.4.0]: https://github.com/dusk-network/merkle/compare/poseidon-merkle_v0.3.0...poseidon-merkle_v0.4.0
 [0.3.0]: https://github.com/dusk-network/merkle/compare/poseidon-merkle_v0.2.1...poseidon-merkle_v0.3.0
 [0.2.1]: https://github.com/dusk-network/merkle/compare/poseidon-merkle_v0.2.0...poseidon-merkle_v0.2.1
 [0.2.0]: https://github.com/dusk-network/merkle/compare/poseidon-merkle_v0.1.0...poseidon-merkle_v0.2.0

--- a/poseidon-merkle/Cargo.toml
+++ b/poseidon-merkle/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "poseidon-merkle"
-description = "Crate implementing Dusk Network's Merkle tree"
-version = "0.3.0"
+description = "Crate implementing Dusk Network's Merkle tree with the poseidon hash function"
+version = "0.4.0"
 
 categories = ["data-structures", "no-std"]
 keywords = ["tree", "merkle", "poseidon", "data", "structure"]


### PR DESCRIPTION
## [0.4.0] - 2023-12-13

### Changed

- Update `dusk-bls12_381` to 0.13
- Update `dusk-plonk` to 0.18
- Update `dusk-poseidon` to 0.32



[0.4.0]: https://github.com/dusk-network/merkle/compare/poseidon-merkle_v0.3.0...poseidon-merkle_v0.4.0
