### PR TITLE
poseidon: Bump to v0.6.0

### DIFF
--- a/poseidon-merkle/CHANGELOG.md
+++ b/poseidon-merkle/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2024-05-22
+
 ### Changed
 
 - Update `dusk-poseidon` to 0.39 [#85]
@@ -58,7 +60,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#58]: https://github.com/dusk-network/merkle/issues/58
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/merkle/compare/poseidon-merkle_v0.5.0...HEAD
+[Unreleased]: https://github.com/dusk-network/merkle/compare/poseidon-merkle_v0.6.0...HEAD
+[0.6.0]: https://github.com/dusk-network/merkle/compare/poseidon-merkle_v0.5.0...poseidon-merkle_v0.6.0
 [0.5.0]: https://github.com/dusk-network/merkle/compare/poseidon-merkle_v0.4.0...poseidon-merkle_v0.5.0
 [0.4.0]: https://github.com/dusk-network/merkle/compare/poseidon-merkle_v0.3.0...poseidon-merkle_v0.4.0
 [0.3.0]: https://github.com/dusk-network/merkle/compare/poseidon-merkle_v0.2.1...poseidon-merkle_v0.3.0

--- a/poseidon-merkle/Cargo.toml
+++ b/poseidon-merkle/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "poseidon-merkle"
 description = "Crate implementing Dusk Network's Merkle tree with the poseidon hash function"
-version = "0.5.0"
+version = "0.6.0"
 
 categories = ["data-structures", "no-std"]
 keywords = ["tree", "merkle", "poseidon", "data", "structure"]


### PR DESCRIPTION
## [0.6.0] - 2024-05-22

### Changed

- Update `dusk-poseidon` to 0.39 [#85]
- Fix `ARITY` in the poseidon-tree to `4` [#85]



[0.6.0]: https://github.com/dusk-network/merkle/compare/poseidon-merkle_v0.5.0...poseidon-
merkle_v0.6.0
