### PR TITLE
poseidon-merkle: bump version to `0.6.1`

### DIFF
--- a/poseidon-merkle/CHANGELOG.md
+++ b/poseidon-merkle/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2024-08-28
+
 ### Added
 
 - Implement `dusk_bytes::Serializable` for `Item<()>`
@@ -64,7 +66,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#58]: https://github.com/dusk-network/merkle/issues/58
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/merkle/compare/poseidon-merkle_v0.6.0...HEAD
+[Unreleased]: https://github.com/dusk-network/merkle/compare/poseidon-merkle_v0.6.1...HEAD
+[0.6.1]: https://github.com/dusk-network/merkle/compare/poseidon-merkle_v0.6.0...poseidon-merkle_v0.6.1
 [0.6.0]: https://github.com/dusk-network/merkle/compare/poseidon-merkle_v0.5.0...poseidon-merkle_v0.6.0
 [0.5.0]: https://github.com/dusk-network/merkle/compare/poseidon-merkle_v0.4.0...poseidon-merkle_v0.5.0
 [0.4.0]: https://github.com/dusk-network/merkle/compare/poseidon-merkle_v0.3.0...poseidon-merkle_v0.4.0

--- a/poseidon-merkle/Cargo.toml
+++ b/poseidon-merkle/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "poseidon-merkle"
 description = "Crate implementing Dusk Network's Merkle tree with the poseidon hash function"
-version = "0.6.0"
+version = "0.6.1"
 
 categories = ["data-structures", "no-std"]
 keywords = ["tree", "merkle", "poseidon", "data", "structure"]


### PR DESCRIPTION
## [poseidon-merkle 0.6.1] - 2024-08-28

### Added

- Implement `dusk_bytes::Serializable` for `Item<()>`

[poseidon-merkle 0.6.1]: https://github.com/dusk-network/merkle/compare/poseidon-merkle_v0.6.0...poseidon-merkle_v0.6.1