### PR TITLE
poseidon-merkle: Bump to v0.7.0

### DIFF
--- a/poseidon-merkle/CHANGELOG.md
+++ b/poseidon-merkle/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2024-08-14
+
+### Changed
+
+- Update `dusk-plonk` to v0.20
+
 ## [0.6.1] - 2024-08-28
 
 ### Added
@@ -66,7 +72,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#58]: https://github.com/dusk-network/merkle/issues/58
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/merkle/compare/poseidon-merkle_v0.6.1...HEAD
+[Unreleased]: https://github.com/dusk-network/merkle/compare/poseidon-merkle_v0.7.0...HEAD
+[0.7.0]: https://github.com/dusk-network/merkle/compare/poseidon-merkle_v0.6.1...poseidon-merkle_v0.7.0
 [0.6.1]: https://github.com/dusk-network/merkle/compare/poseidon-merkle_v0.6.0...poseidon-merkle_v0.6.1
 [0.6.0]: https://github.com/dusk-network/merkle/compare/poseidon-merkle_v0.5.0...poseidon-merkle_v0.6.0
 [0.5.0]: https://github.com/dusk-network/merkle/compare/poseidon-merkle_v0.4.0...poseidon-merkle_v0.5.0

--- a/poseidon-merkle/CHANGELOG.md
+++ b/poseidon-merkle/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update `dusk-plonk` to v0.20
+- Update `dusk-poseidon` to v0.40
 
 ## [0.6.1] - 2024-08-28
 

--- a/poseidon-merkle/Cargo.toml
+++ b/poseidon-merkle/Cargo.toml
@@ -17,7 +17,7 @@ license = "MPL-2.0"
 [dependencies]
 dusk-bytes = "0.1"
 dusk-merkle = "0.5"
-dusk-poseidon = "0.39"
+dusk-poseidon = "0.40"
 dusk-bls12_381 = { version = "0.13", default-features = false }
 dusk-plonk = { version = "0.20", optional = true, default-features = false }
 rkyv = { version = "0.7", optional = true, default-features = false }

--- a/poseidon-merkle/Cargo.toml
+++ b/poseidon-merkle/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "poseidon-merkle"
 description = "Crate implementing Dusk Network's Merkle tree with the poseidon hash function"
-version = "0.6.1"
+version = "0.7.0"
 
 categories = ["data-structures", "no-std"]
 keywords = ["tree", "merkle", "poseidon", "data", "structure"]
@@ -19,7 +19,7 @@ dusk-bytes = "0.1"
 dusk-merkle = "0.5"
 dusk-poseidon = "0.39"
 dusk-bls12_381 = { version = "0.13", default-features = false }
-dusk-plonk = { version = "0.19", optional = true, default-features = false }
+dusk-plonk = { version = "0.20", optional = true, default-features = false }
 rkyv = { version = "0.7", optional = true, default-features = false }
 bytecheck = { version = "0.6", optional = true, default-features = false }
 


### PR DESCRIPTION
## [0.7.0] - 2024-08-14

### Changed

- Update `dusk-plonk` to v0.20
- Update `dusk-poseidon` to v0.40

[0.7.0]: https://github.com/dusk-network/merkle/compare/poseidon-merkle_v0.6.1...poseidon-merkle_v0.7.0