### PR TITLE
Release `dusk-merkle@0.5.3`

### DIFF
--- a/dusk-merkle/CHANGELOG.md
+++ b/dusk-merkle/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.3] - 2024-09-09
+
 ## Added
 
 - Add `Default` implementation for `Tree`
@@ -126,7 +128,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#13]: https://github.com/dusk-network/merkle/issues/13
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/merkle/compare/v0.5.2...HEAD
+[Unreleased]: https://github.com/dusk-network/merkle/compare/v0.5.3...HEAD
+[0.5.3]: https://github.com/dusk-network/merkle/compare/v0.5.2...v0.5.3
 [0.5.2]: https://github.com/dusk-network/merkle/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/dusk-network/merkle/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/dusk-network/merkle/compare/v0.4.0...v0.5.0

--- a/dusk-merkle/Cargo.toml
+++ b/dusk-merkle/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dusk-merkle"
 description = "Crate implementing Dusk Network's Merkle tree"
-version = "0.5.2"
+version = "0.5.3"
 
 categories = ["data-structures", "no-std"]
 keywords = ["tree", "merkle", "hash", "data", "structure"]


### PR DESCRIPTION
## [0.5.3] - 2024-09-09

## Added

- Add `Default` implementation for `Tree`
- Add bounds check on `Tree::insert`, improving panic message [#91]

[0.5.3]: https://github.com/dusk-network/merkle/compare/v0.5.3...v0.5.3