### PR TITLE
Set rust toolchain version to nightly 2023-11-10

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2023-11-10"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
For https://github.com/dusk-network/merkle/issues/96.

`rust-toolchain.toml` uses the latest nightly version instead of a fixed one. This PR temporarily solves the problem of the failing lint by setting the rust version to one in which the lint is absent instead of modifying the code. It will be better to update all the rust toolchain versions used across dusk crates and resolve the new linting errors as a separate issue.

As mentioned in https://github.com/dusk-network/safe/pull/27, most dusk crates use a rust version nightly-2023-11-10, so that is the version chosen to be used here, too.