### PR TITLE
poseidon-merkle: Bump to v0.9.0-rc.0

### DIFF
--- a/poseidon-merkle/CHANGELOG.md
+++ b/poseidon-merkle/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update `dusk-plonk` to `v0.22.0-rc.0`
+- Update `dusk-poseidon` to `v0.42.0-rc.0`
+- Update to rust stable version 1.85, edition 2024
+
 ## [0.8.0] - 2025-02-07
 
 ### Changed

--- a/poseidon-merkle/Cargo.toml
+++ b/poseidon-merkle/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "poseidon-merkle"
 description = "Crate implementing Dusk Network's Merkle tree with the poseidon hash function"
-version = "0.8.0"
+version = "0.9.0-rc.0"
 
 categories = ["data-structures", "no-std"]
 keywords = ["tree", "merkle", "poseidon", "data", "structure"]
@@ -11,7 +11,7 @@ authors = [
     "Moana Marcello <moana@dusk.network>",
 ]
 
-edition = "2021"
+edition = "2024"
 rust-version = "1.85"
 license = "MPL-2.0"
 

--- a/poseidon-merkle/benches/poseidon.rs
+++ b/poseidon-merkle/benches/poseidon.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
 
 use dusk_bls12_381::BlsScalar;
 use dusk_poseidon::{Domain, Hash};

--- a/poseidon-merkle/benches/zk.rs
+++ b/poseidon-merkle/benches/zk.rs
@@ -6,10 +6,10 @@
 
 // to be able to use this module, the "poseidon" feature needs to be in scope
 
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 
 use dusk_plonk::prelude::*;
-use poseidon_merkle::{zk::opening_gadget, Item, Opening, Tree};
+use poseidon_merkle::{Item, Opening, Tree, zk::opening_gadget};
 
 use rand::rngs::StdRng;
 use rand::{RngCore, SeedableRng};

--- a/poseidon-merkle/src/zk.rs
+++ b/poseidon-merkle/src/zk.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use crate::{Opening, ARITY};
+use crate::{ARITY, Opening};
 
 use dusk_merkle::Aggregate;
 use dusk_plonk::prelude::{BlsScalar, Composer, Constraint, Witness};


### PR DESCRIPTION
- Update `dusk-plonk` to `v0.22.0-rc.0`
- Update `dusk-poseidon` to `v0.42.0-rc.0`
- Update to rust stable version 1.85, edition 2024
