### PR TITLE
AI-friendliness pass

### DIFF
--- a/.github/workflows/dusk_ci.yml
+++ b/.github/workflows/dusk_ci.yml
@@ -18,14 +18,32 @@ jobs:
     name: Dusk Analyzer
     uses: dusk-network/.github/.github/workflows/dusk-analysis.yml@main
 
-  tests_dusk_merkle:
-    name: tests dusk-merkle
-    uses: dusk-network/.github/.github/workflows/run-tests.yml@main
-    with:
-      test_flags: -p dusk-merkle --features=rkyv-impl,size_32
+  test:
+    name: Tests
+    runs-on: core
+    steps:
+      - uses: actions/checkout@v4
+      - name: Add Rust tools to PATH
+        run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+      - uses: dsherret/rust-toolchain-file@v1
+      - name: Enable sccache
+        run: |
+          if command -v sccache >/dev/null; then
+            echo "RUSTC_WRAPPER=$(command -v sccache)" >> "$GITHUB_ENV"
+          fi
+      - run: make test
 
-  tests_poseidon_merkle:
-    name: tests poseidon-merkle
-    uses: dusk-network/.github/.github/workflows/run-tests.yml@main
-    with:
-      test_flags: -p poseidon-merkle --features=zk,rkyv-impl,size_32
+  no-std:
+    name: Bare-metal no_std
+    runs-on: core
+    steps:
+      - uses: actions/checkout@v4
+      - name: Add Rust tools to PATH
+        run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+      - uses: dsherret/rust-toolchain-file@v1
+      - name: Enable sccache
+        run: |
+          if command -v sccache >/dev/null; then
+            echo "RUSTC_WRAPPER=$(command -v sccache)" >> "$GITHUB_ENV"
+          fi
+      - run: make no-std

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,139 @@
+# Merkle
+
+Sparse Merkle tree implementation for the Dusk network. Workspace with two `no_std` crates: a generic tree with openings (proofs), and a Poseidon-hashed variant with optional ZK circuit support.
+
+## Repository Map
+
+```
+merkle/
+├── dusk-merkle/       # dusk-merkle — generic sparse Merkle tree with openings
+├── poseidon-merkle/   # poseidon-merkle — Poseidon-hashed tree (arity 4), ZK circuits
+└── Makefile           # Root Makefile delegating to member crates
+```
+
+### `dusk-merkle/` (`dusk-merkle`)
+
+Generic sparse Merkle tree parameterized by leaf type `T`, height `H`, and arity `A`:
+
+- **`src/tree.rs`** — `Tree<T, H, A>` struct with sparse storage and lazy hash computation
+- **`src/opening.rs`** — Merkle opening (proof) generation and verification
+- **`src/node.rs`** — Internal node with lazy hash computation
+
+### `poseidon-merkle/` (`poseidon-merkle`)
+
+Poseidon-hashed Merkle tree (arity 4) built on `dusk-merkle`:
+
+- **`src/lib.rs`** — Type aliases for Poseidon-specific tree and opening
+- **`src/zk.rs`** — ZK circuit gadgets for Merkle proof verification (feature-gated behind `zk`)
+
+## Commands
+
+```bash
+make test          # Run all tests (dusk-merkle + poseidon-merkle, --release)
+make no-std        # Verify bare-metal target compatibility (thumbv6m-none-eabi)
+make clippy        # Run clippy on all crates
+make fmt           # Format code (requires nightly toolchain)
+make check         # Run cargo check
+make doc           # Generate documentation
+make clean         # Clean build artifacts
+```
+
+Tests use `--release` because `poseidon-merkle` depends on `dusk-plonk` (via the `zk` feature) — debug builds take extremely long for PLONK proofs.
+
+## Feature Flags
+
+### `dusk-merkle`
+
+| Feature    | Description                                    | Default |
+|------------|------------------------------------------------|---------|
+| `rkyv-impl`| rkyv serialization with validation and alloc  | No      |
+| `size_16`  | rkyv 16-bit pointer size (mutually exclusive) | No      |
+| `size_32`  | rkyv 32-bit pointer size (mutually exclusive) | No      |
+| `size_64`  | rkyv 64-bit pointer size (mutually exclusive) | No      |
+
+### `poseidon-merkle`
+
+| Feature    | Description                                    | Default |
+|------------|------------------------------------------------|---------|
+| `zk`       | PLONK circuit support via `dusk-plonk`        | No      |
+| `rkyv-impl`| rkyv serialization (enables on bls12_381 and dusk-merkle too) | No |
+| `size_16`  | rkyv 16-bit pointer size (mutually exclusive) | No      |
+| `size_32`  | rkyv 32-bit pointer size (mutually exclusive) | No      |
+| `size_64`  | rkyv 64-bit pointer size (mutually exclusive) | No      |
+
+**Note:** The `size_*` features are mutually exclusive — `--all-features` will fail. Use specific feature combinations (e.g. `--features=rkyv-impl,size_32`).
+
+## Architecture
+
+### Sparse Merkle Tree
+
+The tree is a **sparse** data structure — only populated leaves and their ancestor nodes are stored. Empty subtrees use a default hash. The tree supports:
+
+- **Variable height and arity**: Parameterized at the type level (`H` for height, `A` for arity)
+- **Lazy hash computation**: Internal nodes recompute hashes only when children change
+- **Openings (proofs)**: A Merkle opening contains the sibling hashes along the path from a leaf to the root, enabling verification that a leaf belongs to the tree
+
+### Poseidon Variant
+
+`poseidon-merkle` specializes the generic tree with:
+
+- **Poseidon hash** over the BLS12-381 scalar field (via `dusk-poseidon`)
+- **Arity 4** — each internal node has 4 children
+- **ZK circuit gadgets** (behind `zk` feature) for in-circuit Merkle proof verification using `dusk-plonk`
+
+### Key Dependencies
+
+- `dusk-bls12_381` — BLS12-381 scalar field (leaf type for Poseidon tree)
+- `dusk-poseidon` — Poseidon hash function
+- `dusk-plonk` — PLONK proving system (optional, `zk` feature)
+- `dusk-bytes` — Canonical byte serialization
+- `rkyv` — Zero-copy deserialization (optional, `rkyv-impl` feature)
+
+## Conventions
+
+- **`no_std`**: Both crates are `no_std`. Do not add `std` dependencies.
+- **Serialization**: Use `dusk-bytes` for canonical byte encoding, `rkyv` for zero-copy deserialization (feature-gated).
+- **Field ordering**: Do not reorder fields in `rkyv`-serializable structs — it breaks archive compatibility.
+- **Edition 2024**: The workspace uses Rust edition 2024 with MSRV 1.85.
+- **`--release` for tests**: Always use `--release` when running tests that exercise PLONK proofs (`poseidon-merkle` with `zk` feature).
+
+## Elevated Care Zones
+
+`poseidon-merkle` with the `zk` feature enabled is cryptographic code — Merkle proof verification circuits must be correct for the integrity of the Dusk note tree. Changes to `src/zk.rs` or the hash computation in either crate require careful review.
+
+## Change Propagation
+
+| Changed crate     | Also verify                                |
+|--------------------|--------------------------------------------|
+| `dusk-merkle`      | `poseidon-merkle`, `piecrust`, `rusk`      |
+| `poseidon-merkle`  | `phoenix`, `rusk`                          |
+
+## Git Conventions
+
+- Default branch: `main`
+- License: MPL-2.0
+
+### Commit messages
+
+Format: `<scope>: <Description>` — imperative mood, capitalize first word after colon.
+
+**One commit per crate per concern.** Each commit touches exactly one crate and one logical concern. Never bundle changes to different crates in one commit, and don't mix unrelated changes within the same crate either. Order commits bottom-up through the dependency chain (`dusk-merkle` before `poseidon-merkle`).
+
+Canonical scopes:
+
+| Scope | Crate/Directory |
+|-------|----------------|
+| `dusk-merkle` | `dusk-merkle/` |
+| `poseidon-merkle` | `poseidon-merkle/` |
+| `workspace` | Root `Cargo.toml`, root Makefile |
+| `ci` | `.github/workflows/` |
+| `chore` | Makefile, rustfmt, etc. |
+
+Examples:
+- `dusk-merkle: Add rkyv support for Opening`
+- `poseidon-merkle: Fix ZK circuit witness generation`
+- `workspace: Update dusk dependencies`
+
+### Changelog
+
+Both crates have a `CHANGELOG.md`. Add entries under `[Unreleased]` using [keep-a-changelog](https://keepachangelog.com/) format. If a change traces to a GitHub issue, reference it as a link: `[#42](https://github.com/dusk-network/merkle/issues/42)`. Only link to GitHub issues — do not reference any other tracking system.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+help: ## Display this help screen
+	@grep -h -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+test: ## Run all tests
+	@$(MAKE) -C ./dusk-merkle $@
+	@$(MAKE) -C ./poseidon-merkle $@
+
+no-std: ## Verify no_std compatibility on bare-metal target
+	@$(MAKE) -C ./dusk-merkle $@
+	@$(MAKE) -C ./poseidon-merkle $@
+
+clippy: ## Run clippy
+	@$(MAKE) -C ./dusk-merkle $@
+	@$(MAKE) -C ./poseidon-merkle $@
+
+fmt: ## Format code (requires nightly)
+	@cargo +nightly fmt --all
+
+check: ## Run cargo check
+	@cargo check
+
+doc: ## Generate documentation
+	@cargo doc --no-deps
+
+clean: ## Clean build artifacts
+	@cargo clean
+
+.PHONY: help test no-std clippy fmt check doc clean

--- a/dusk-merkle/Makefile
+++ b/dusk-merkle/Makefile
@@ -1,0 +1,15 @@
+help: ## Display this help screen
+	@grep -h -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+test: ## Run dusk-merkle tests
+	@cargo test --release -p dusk-merkle --features=rkyv-impl,size_32
+
+no-std: ## Verify no_std compatibility on bare-metal target
+	@rustup target add thumbv6m-none-eabi
+	@cargo build --release -p dusk-merkle --no-default-features --target thumbv6m-none-eabi
+
+clippy: ## Run clippy
+	@cargo clippy -p dusk-merkle --features=rkyv-impl,size_32 -- -D warnings
+
+.PHONY: help test no-std clippy

--- a/dusk-merkle/benches/blake3.rs
+++ b/dusk-merkle/benches/blake3.rs
@@ -4,14 +4,11 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+use blake3::{Hash as Blake3Hash, Hasher};
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
-
+use dusk_merkle::{Aggregate, Tree};
 use rand::rngs::StdRng;
 use rand::{RngCore, SeedableRng};
-
-use blake3::{Hash as Blake3Hash, Hasher};
-
-use dusk_merkle::{Aggregate, Tree};
 
 const EMPTY_HASH: Item = Item([0; 32]);
 

--- a/dusk-merkle/examples/annotation.rs
+++ b/dusk-merkle/examples/annotation.rs
@@ -9,7 +9,6 @@ use std::time::Instant;
 
 use blake3::{Hash as Blake3Hash, Hasher};
 use dusk_merkle::{Aggregate, Tree as MerkleTree};
-
 use rand::rngs::StdRng;
 use rand::{RngCore, SeedableRng};
 

--- a/dusk-merkle/src/node.rs
+++ b/dusk-merkle/src/node.rs
@@ -141,16 +141,17 @@ where
 #[cfg(feature = "rkyv-impl")]
 #[allow(unsafe_op_in_unsafe_fn)]
 mod rkyv_impl {
-    use super::Node;
-
     use alloc::boxed::Box;
     use core::cell::RefCell;
 
     use bytecheck::CheckBytes;
+    use rkyv::ser::Serializer;
     use rkyv::{
         Archive, Archived, Deserialize, Fallible, Resolver, Serialize,
-        out_field, ser::Serializer,
+        out_field,
     };
+
+    use super::Node;
 
     #[derive(CheckBytes)]
     #[check_bytes(

--- a/dusk-merkle/src/opening.rs
+++ b/dusk-merkle/src/opening.rs
@@ -4,8 +4,6 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use crate::{Aggregate, Node, Tree, init_array};
-
 use alloc::vec::Vec;
 
 #[cfg(feature = "rkyv-impl")]
@@ -13,6 +11,8 @@ use bytecheck::CheckBytes;
 use dusk_bytes::{DeserializableSlice, Error as BytesError, Serializable};
 #[cfg(feature = "rkyv-impl")]
 use rkyv::{Archive, Deserialize, Serialize};
+
+use crate::{Aggregate, Node, Tree, init_array};
 
 /// An opening for a given position in a merkle tree.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]

--- a/dusk-merkle/tests/serializable_opening.rs
+++ b/dusk-merkle/tests/serializable_opening.rs
@@ -9,7 +9,6 @@ use std::cmp;
 use dusk_bls12_381::BlsScalar;
 use dusk_bytes::{DeserializableSlice, Error as BytesError, Serializable};
 use dusk_merkle::{Aggregate, Opening, Tree};
-
 use ff::Field;
 use rand::rngs::StdRng;
 use rand::{RngCore, SeedableRng};

--- a/poseidon-merkle/Makefile
+++ b/poseidon-merkle/Makefile
@@ -1,0 +1,15 @@
+help: ## Display this help screen
+	@grep -h -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+test: ## Run poseidon-merkle tests
+	@cargo test --release -p poseidon-merkle --features=zk,rkyv-impl,size_32
+
+no-std: ## Verify no_std compatibility on bare-metal target
+	@rustup target add thumbv6m-none-eabi
+	@cargo build --release -p poseidon-merkle --no-default-features --target thumbv6m-none-eabi
+
+clippy: ## Run clippy
+	@cargo clippy -p poseidon-merkle --features=zk,rkyv-impl,size_32 -- -D warnings
+
+.PHONY: help test no-std clippy

--- a/poseidon-merkle/benches/poseidon.rs
+++ b/poseidon-merkle/benches/poseidon.rs
@@ -5,11 +5,9 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 use criterion::{Criterion, black_box, criterion_group, criterion_main};
-
 use dusk_bls12_381::BlsScalar;
 use dusk_poseidon::{Domain, Hash};
 use poseidon_merkle::{Item, Tree};
-
 use rand::{RngCore, SeedableRng};
 
 const HEIGHT: usize = 17;

--- a/poseidon-merkle/benches/zk.rs
+++ b/poseidon-merkle/benches/zk.rs
@@ -7,10 +7,9 @@
 // to be able to use this module, the "poseidon" feature needs to be in scope
 
 use criterion::{Criterion, criterion_group, criterion_main};
-
 use dusk_plonk::prelude::*;
-use poseidon_merkle::{Item, Opening, Tree, zk::opening_gadget};
-
+use poseidon_merkle::zk::opening_gadget;
+use poseidon_merkle::{Item, Opening, Tree};
 use rand::rngs::StdRng;
 use rand::{RngCore, SeedableRng};
 

--- a/poseidon-merkle/examples/zk.rs
+++ b/poseidon-merkle/examples/zk.rs
@@ -7,13 +7,12 @@
 use dusk_plonk::prelude::*;
 use dusk_poseidon::{Domain, Hash};
 use ff::Field;
-use rand::rngs::StdRng;
-use rand::{RngCore, SeedableRng};
-
 use poseidon_merkle::zk::opening_gadget;
 use poseidon_merkle::{
     Item as PoseidonItem, Opening as PoseidonOpening, Tree as PoseidonTree,
 };
+use rand::rngs::StdRng;
+use rand::{RngCore, SeedableRng};
 
 // set max circuit size to 2^16 gates
 const CAPACITY: usize = 16;

--- a/poseidon-merkle/src/zk.rs
+++ b/poseidon-merkle/src/zk.rs
@@ -4,11 +4,11 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use crate::{ARITY, Opening};
-
 use dusk_merkle::Aggregate;
 use dusk_plonk::prelude::{BlsScalar, Composer, Constraint, Witness};
 use dusk_poseidon::{Domain, HashGadget};
+
+use crate::{ARITY, Opening};
 
 /// Builds the gadget for the poseidon opening and returns the computed
 /// root.

--- a/poseidon-merkle/tests/zk.rs
+++ b/poseidon-merkle/tests/zk.rs
@@ -4,16 +4,13 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use poseidon_merkle::zk::opening_gadget;
-use poseidon_merkle::{Item, Opening, Tree};
-
 use dusk_plonk::prelude::*;
 use dusk_poseidon::{Domain, Hash};
-
+use ff::Field;
+use poseidon_merkle::zk::opening_gadget;
+use poseidon_merkle::{Item, Opening, Tree};
 use rand::rngs::StdRng;
 use rand::{RngCore, SeedableRng};
-
-use ff::Field;
 
 // set max circuit size to 2^15 gates
 const CAPACITY: usize = 15;

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,6 @@
 max_width = 80
+unstable_features = true
+group_imports = "StdExternalCrate"
+imports_granularity = "Module"
+use_field_init_shorthand = true
+wrap_comments = true


### PR DESCRIPTION
## Summary

Brings merkle up to the AI-friendliness baseline established across other Dusk repos:

- **Layered Makefiles**: root delegates `test`, `clippy`, `no-std` to per-crate Makefiles; shared targets (`fmt`, `check`, `doc`, `clean`) at root
- **CI**: replaces reusable `run-tests.yml` calls with inline `make test` and `make no-std` jobs on `core` runners, with `dsherret/rust-toolchain-file@v1` and sccache support; `code_analysis` and `dusk_analyzer` shared workflows unchanged
- **rustfmt.toml**: adds `group_imports`, `imports_granularity`, `use_field_init_shorthand`, `wrap_comments`; formatting applied per crate
- **AGENTS.md**: full agent guide (repo map, commands, features, architecture, conventions, git scoping, changelog); `CLAUDE.md` symlinked to it