### PR TITLE
dusk-merkle: Validate position bounds in Opening::from_slice

### DIFF
--- a/dusk-merkle/CHANGELOG.md
+++ b/dusk-merkle/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Reject out-of-range position values during `Opening::from_slice` deserialization
 - Fix `unsafe_op_in_unsafe_fn` warnings for edition 2024
 
 ## [0.5.3] - 2024-09-09

--- a/dusk-merkle/src/opening.rs
+++ b/dusk-merkle/src/opening.rs
@@ -169,7 +169,11 @@ where
         // deserialize positions
         let mut positions = [0usize; H];
         for pos in &mut positions {
-            *pos = u32::from_reader(&mut bytes)? as usize;
+            let p = u32::from_reader(&mut bytes)? as usize;
+            if p >= A {
+                return Err(BytesError::InvalidData);
+            }
+            *pos = p;
         }
 
         Ok(Self {

--- a/dusk-merkle/tests/serializable_opening.rs
+++ b/dusk-merkle/tests/serializable_opening.rs
@@ -157,3 +157,31 @@ fn serialize_deserialize() {
     assert!(deserialized.verify(leaf));
     assert_eq!(opening, deserialized);
 }
+
+#[test]
+fn out_of_range_position_rejected() {
+    let tree = &mut MerkleTree::new();
+    let mut rng = StdRng::seed_from_u64(0xbeef);
+
+    let leaf = Item {
+        hash: BlsScalar::random(&mut rng),
+        bh_range: Some(Range { start: 0, end: 0 }),
+    };
+    tree.insert(0, leaf);
+
+    let opening = tree.opening(0).unwrap();
+    let mut serialized = opening.to_var_bytes::<ITEM_SIZE>();
+
+    // The positions are stored as u32 values at the end of the serialized
+    // opening. Overwrite the first position with a value >= A to simulate
+    // a crafted opening with an out-of-range position.
+    let positions_offset = (1 + H * A) * ITEM_SIZE;
+    let bad_position = A as u32;
+    serialized[positions_offset..positions_offset + 4]
+        .copy_from_slice(&bad_position.to_le_bytes());
+
+    assert!(
+        Opening::<Item, H, A>::from_slice::<ITEM_SIZE>(&serialized).is_err(),
+        "Deserialization should reject a position >= A"
+    );
+}


### PR DESCRIPTION
Reject `position >= A` (the tree arity) during deserialization, returning `InvalidData` instead of allowing crafted openings that would later panic with an array index out-of-bounds in `verify()`.
