### PR TITLE
Update dependencies: Plonk, Poseidon, and Curves

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,8 @@ make clean         # Clean build artifacts
 
 Tests use `--release` because `poseidon-merkle` depends on `dusk-plonk` (via the `zk` feature) — debug builds take extremely long for PLONK proofs.
 
+The `poseidon-merkle` no-std build uses the BLST backend. Its Makefile sets `CC_thumbv6m_none_eabi=clang` and target C flags so the `blst` C dependency can cross-compile to `thumbv6m-none-eabi` without requiring `arm-none-eabi-gcc`.
+
 ## Feature Flags
 
 ### `dusk-merkle`
@@ -55,13 +57,17 @@ Tests use `--release` because `poseidon-merkle` depends on `dusk-plonk` (via the
 
 | Feature    | Description                                    | Default |
 |------------|------------------------------------------------|---------|
+| `bls-backend-dusk` | Select the Dusk BLS12-381 backend through `dusk-curves` | No |
+| `bls-backend-blst` | Select the blst BLS12-381 backend through `dusk-curves` | No |
 | `zk`       | PLONK circuit support via `dusk-plonk`        | No      |
-| `rkyv-impl`| rkyv serialization (enables on bls12_381 and dusk-merkle too) | No |
+| `rkyv-impl`| rkyv serialization (enables on dusk-curves and dusk-merkle too) | No |
 | `size_16`  | rkyv 16-bit pointer size (mutually exclusive) | No      |
 | `size_32`  | rkyv 32-bit pointer size (mutually exclusive) | No      |
 | `size_64`  | rkyv 64-bit pointer size (mutually exclusive) | No      |
 
-**Note:** The `size_*` features are mutually exclusive — `--all-features` will fail. Use specific feature combinations (e.g. `--features=rkyv-impl,size_32`).
+**Note:** The `size_*` features are mutually exclusive — `--all-features` will fail. Use specific feature combinations (e.g. `--features=rkyv-impl,size_32`). For `poseidon-merkle`, `rkyv-impl` forwards to `dusk-curves/rkyv-impl`, which uses rkyv size 32.
+
+**Note:** `poseidon-merkle` does not select a BLS12-381 backend by default. Consumers must enable exactly one of `bls-backend-dusk` or `bls-backend-blst`; local repo and CI commands use `bls-backend-blst`.
 
 ## Architecture
 
@@ -83,7 +89,7 @@ The tree is a **sparse** data structure — only populated leaves and their ance
 
 ### Key Dependencies
 
-- `dusk-bls12_381` — BLS12-381 scalar field (leaf type for Poseidon tree)
+- `dusk-curves` — BLS12-381 scalar field facade (leaf type for Poseidon tree; backend selected by consumer)
 - `dusk-poseidon` — Poseidon hash function
 - `dusk-plonk` — PLONK proving system (optional, `zk` feature)
 - `dusk-bytes` — Canonical byte serialization

--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,12 @@ fmt: ## Format code (requires nightly)
 	@cargo +nightly fmt --all $(if $(CHECK),-- --check,)
 
 check: ## Run cargo check
-	@cargo check
+	@cargo check -p dusk-merkle
+	@cargo check -p poseidon-merkle --features=bls-backend-blst
 
 doc: ## Generate documentation
-	@cargo doc --no-deps
+	@cargo doc -p dusk-merkle --no-deps
+	@cargo doc -p poseidon-merkle --no-deps --features=bls-backend-blst
 
 clean: ## Clean build artifacts
 	@cargo clean

--- a/dusk-merkle/CHANGELOG.md
+++ b/dusk-merkle/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update `dusk-bls12_381` dev dependency to v0.14
+- Replace `dusk-bls12_381` dev dependency with `dusk-curves` v0.2 using the BLST backend
 - Update to rust stable version 1.85, edition 2024
 
 ### Fixed

--- a/dusk-merkle/Cargo.toml
+++ b/dusk-merkle/Cargo.toml
@@ -23,7 +23,7 @@ bytecheck = { version = "0.6", optional = true, default-features = false }
 [dev-dependencies]
 blake3 = "1"
 rand = "0.8"
-dusk-bls12_381 = "0.14"
+dusk-curves = { version = "0.2", default-features = false, features = ["bls-backend-blst"] }
 ff = { version = "0.13", default-features = false }
 criterion = "0.3"
 

--- a/dusk-merkle/README.md
+++ b/dusk-merkle/README.md
@@ -82,19 +82,20 @@ cargo bench
 
 For the `poseidon` tree:
 ```shell
-cargo bench -p poseidon-merkle
+cargo bench -p poseidon-merkle --features bls-backend-blst
 ```
 
 For the opening proof creation in zero-knowledge:
 ```shell
-cargo bench -p poseidon-merkle --features zk
+cargo bench -p poseidon-merkle --features bls-backend-blst,zk
 ```
 
 ## Implementations
 
 A merkle tree using the poseidon hash function for aggregation and plonk to
 generate an opening proof in zero-knowledge can be found in the same workspace
-under 'poseidon-merkle'.
+under 'poseidon-merkle'. Consumers of that crate must enable exactly one
+BLS12-381 backend feature, `bls-backend-dusk` or `bls-backend-blst`.
 
 ## License
 

--- a/dusk-merkle/tests/serializable_opening.rs
+++ b/dusk-merkle/tests/serializable_opening.rs
@@ -6,8 +6,8 @@
 
 use std::cmp;
 
-use dusk_bls12_381::BlsScalar;
 use dusk_bytes::{DeserializableSlice, Error as BytesError, Serializable};
+use dusk_curves::bls12_381::BlsScalar;
 use dusk_merkle::{Aggregate, Opening, Tree};
 use ff::Field;
 use rand::rngs::StdRng;

--- a/poseidon-merkle/CHANGELOG.md
+++ b/poseidon-merkle/CHANGELOG.md
@@ -9,8 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update `dusk-plonk` to `v0.22.0-rc.0`
-- Update `dusk-poseidon` to `v0.42.0-rc.0`
+- Update `dusk-plonk` to v0.23
+- Update `dusk-poseidon` to v0.43
+- Replace `dusk-bls12_381` with `dusk-curves` v0.2
+- Add `bls-backend-dusk` and `bls-backend-blst` features for consumers to select the BLS12-381 backend
+- Use the BLST backend in local and CI verification commands
 - Update `dusk-merkle` to `v0.6.0-rc.0`
 - Update to rust stable version 1.85, edition 2024
 

--- a/poseidon-merkle/Cargo.toml
+++ b/poseidon-merkle/Cargo.toml
@@ -15,12 +15,15 @@ edition = "2024"
 rust-version = "1.85"
 license = "MPL-2.0"
 
+[package.metadata.docs.rs]
+features = ["bls-backend-blst"]
+
 [dependencies]
 dusk-bytes = "0.1"
 dusk-merkle.workspace = true
-dusk-poseidon = "0.42.0-rc.0"
-dusk-bls12_381 = { version = "0.14", default-features = false }
-dusk-plonk = { version = "0.22.0-rc.0", optional = true, default-features = false }
+dusk-curves = { version = "0.2", default-features = false }
+dusk-poseidon = { version = "0.43", default-features = false }
+dusk-plonk = { version = "0.23", optional = true, default-features = false }
 rkyv = { version = "0.7", optional = true, default-features = false }
 bytecheck = { version = "0.6", optional = true, default-features = false }
 
@@ -30,7 +33,18 @@ criterion = "0.3"
 ff = { version = "0.13", default-features = false }
 
 [features]
-zk = ["dusk-plonk/alloc", "dusk-poseidon/zk"]
+default = []
+bls-backend-blst = [
+    "dusk-curves/bls-backend-blst",
+    "dusk-poseidon/bls-backend-blst",
+    "dusk-plonk?/bls-backend-blst",
+]
+bls-backend-dusk = [
+    "dusk-curves/bls-backend-dusk",
+    "dusk-poseidon/bls-backend-dusk",
+    "dusk-plonk?/bls-backend-dusk",
+]
+zk = ["dep:dusk-plonk", "dusk-plonk/alloc", "dusk-poseidon/zk"]
 size_16 = ["rkyv/size_16"]
 size_32 = ["rkyv/size_32"]
 size_64 = ["rkyv/size_64"]
@@ -39,7 +53,7 @@ rkyv-impl = [
     "rkyv/alloc",
     "rkyv",
     "bytecheck",
-    "dusk-bls12_381/rkyv-impl",
+    "dusk-curves/rkyv-impl",
     "dusk-merkle/rkyv-impl",
 ]
 

--- a/poseidon-merkle/Makefile
+++ b/poseidon-merkle/Makefile
@@ -2,15 +2,18 @@ help: ## Display this help screen
 	@grep -h -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
 		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
+BLST_CC ?= clang
+BLST_CFLAGS ?= --target=thumbv6m-none-eabi -mthumb
+
 test: ## Run poseidon-merkle tests
-	@cargo test --release -p poseidon-merkle --features=zk,rkyv-impl,size_32
+	@cargo test --release -p poseidon-merkle --features=bls-backend-blst,zk,rkyv-impl,size_32
 
 no-std: ## Verify no_std compatibility on bare-metal target
 	@rustup target add thumbv6m-none-eabi
-	@cargo build --release -p poseidon-merkle --no-default-features --target thumbv6m-none-eabi
+	@CC_thumbv6m_none_eabi=$(BLST_CC) CFLAGS_thumbv6m_none_eabi="$(BLST_CFLAGS)" cargo build --release -p poseidon-merkle --no-default-features --features=bls-backend-blst --target thumbv6m-none-eabi
 
 clippy: ## Run clippy
-	@cargo clippy -p poseidon-merkle --features=zk,rkyv-impl,size_32 -- -D warnings
-	@cargo clippy -p poseidon-merkle --no-default-features -- -D warnings
+	@cargo clippy -p poseidon-merkle --features=bls-backend-blst,zk,rkyv-impl,size_32 -- -D warnings
+	@cargo clippy -p poseidon-merkle --no-default-features --features=bls-backend-blst -- -D warnings
 
 .PHONY: help test no-std clippy

--- a/poseidon-merkle/README.md
+++ b/poseidon-merkle/README.md
@@ -27,16 +27,30 @@ The type `Item<T>` has the aggregation of the `hash` part with the poseidon hash
 pre-defined and additionally allows for a custom data type with custom
 aggregation.
 
+## Features
+
+This crate does not select a BLS12-381 backend by default. Consumers must enable
+exactly one backend feature:
+
+- `bls-backend-dusk`
+- `bls-backend-blst`
+
+The selected backend is forwarded to `dusk-curves`, `dusk-poseidon`, and to
+`dusk-plonk` when the `zk` feature is enabled.
+
+The `rkyv-impl` feature forwards to `dusk-curves/rkyv-impl`, which uses rkyv
+size 32.
+
 ## Benchmarks
 
 There are benchmarks for the poseidon tree calculation available with
 ```shell
-cargo bench
+cargo bench --features bls-backend-blst
 ```
 
 and additional benchmarks for the opening proof generation with PLONK
 ```shell
-cargo bench --features zk
+cargo bench --features bls-backend-blst,zk
 ```
 
 This requires a nightly toolchain.

--- a/poseidon-merkle/benches/poseidon.rs
+++ b/poseidon-merkle/benches/poseidon.rs
@@ -5,7 +5,7 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 use criterion::{Criterion, black_box, criterion_group, criterion_main};
-use dusk_bls12_381::BlsScalar;
+use dusk_curves::bls12_381::BlsScalar;
 use dusk_poseidon::{Domain, Hash};
 use poseidon_merkle::{Item, Tree};
 use rand::{RngCore, SeedableRng};

--- a/poseidon-merkle/benches/zk.rs
+++ b/poseidon-merkle/benches/zk.rs
@@ -8,6 +8,7 @@
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use dusk_plonk::prelude::*;
+use dusk_poseidon::{Domain, Hash};
 use poseidon_merkle::zk::opening_gadget;
 use poseidon_merkle::{Item, Opening, Tree};
 use rand::rngs::StdRng;
@@ -16,17 +17,16 @@ use rand::{RngCore, SeedableRng};
 // set max circuit size to 2^13 gates
 const CAPACITY: usize = 16;
 
-// set height and arity of the poseidon merkle tree
+// set height of the poseidon merkle tree
 const HEIGHT: usize = 17;
-const ARITY: usize = 4;
 
-type PoseidonTree = Tree<(), HEIGHT, ARITY>;
+type PoseidonTree = Tree<(), HEIGHT>;
 type PoseidonItem = Item<()>;
 
 // Create a circuit for the opening
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 struct OpeningCircuit {
-    opening: Opening<(), HEIGHT, ARITY>,
+    opening: Opening<(), HEIGHT>,
     leaf: PoseidonItem,
 }
 
@@ -48,10 +48,7 @@ impl Default for OpeningCircuit {
 
 impl OpeningCircuit {
     /// Create a new OpeningCircuit
-    pub fn new(
-        opening: Opening<(), HEIGHT, ARITY>,
-        leaf: PoseidonItem,
-    ) -> Self {
+    pub fn new(opening: Opening<(), HEIGHT>, leaf: PoseidonItem) -> Self {
         Self { opening, leaf }
     }
 }
@@ -88,7 +85,7 @@ fn bench_zk(c: &mut Criterion) {
     for _ in 0..100 {
         let pos = rng.next_u64() % u32::MAX as u64;
         let leaf = PoseidonItem {
-            hash: dusk_poseidon::sponge::hash(&[pos.into()]),
+            hash: Hash::digest(Domain::Other, &[pos.into()])[0],
             data: (),
         };
         tree.insert(pos, leaf);
@@ -97,7 +94,7 @@ fn bench_zk(c: &mut Criterion) {
     // insert new leaf in the tree at random position to create opening
     let pos = rng.next_u64() % u32::MAX as u64;
     let leaf = PoseidonItem {
-        hash: dusk_poseidon::sponge::hash(&[pos.into()]),
+        hash: Hash::digest(Domain::Other, &[pos.into()])[0],
         data: (),
     };
     tree.insert(pos, leaf);

--- a/poseidon-merkle/src/lib.rs
+++ b/poseidon-merkle/src/lib.rs
@@ -11,8 +11,26 @@
 #[cfg(feature = "zk")]
 pub mod zk;
 
-use dusk_bls12_381::BlsScalar;
+#[cfg(all(feature = "bls-backend-dusk", feature = "bls-backend-blst"))]
+compile_error!(
+    "features 'bls-backend-dusk' and 'bls-backend-blst' are mutually exclusive"
+);
+
+#[cfg(not(any(feature = "bls-backend-dusk", feature = "bls-backend-blst")))]
+compile_error!(
+    "no BLS12-381 backend selected: enable either 'bls-backend-dusk' or 'bls-backend-blst'"
+);
+
+#[cfg(all(
+    feature = "rkyv-impl",
+    any(feature = "size_16", feature = "size_64")
+))]
+compile_error!(
+    "feature 'rkyv-impl' requires rkyv size 32 through 'dusk-curves/rkyv-impl'"
+);
+
 use dusk_bytes::Serializable;
+use dusk_curves::bls12_381::BlsScalar;
 use dusk_merkle::Aggregate;
 use dusk_poseidon::{Domain, Hash};
 
@@ -35,7 +53,7 @@ pub type Opening<T, const H: usize> = dusk_merkle::Opening<Item<T>, H, ARITY>;
 /// ```rust
 /// use std::cmp::{max, min};
 ///
-/// use dusk_bls12_381::BlsScalar;
+/// use dusk_curves::bls12_381::BlsScalar;
 /// use dusk_merkle::Aggregate;
 /// use dusk_poseidon::{Domain, Hash};
 /// use poseidon_merkle::{ARITY, Item, Tree as PoseidonTree};


### PR DESCRIPTION
This PR updates the Plonk, Poseidon, and curves dependencies:
- plonk -> dusk_plonk 0.23
- poseidon -> dusk_poseidon 0.43
- dusk_bls12-381 -> dusk_curves 0.2

It also makes some necessary API and CI adjustments. For the tests, the selected backend is BLST. The bls-backend-... feature is however forwarded, so it's selected by consumer.

It also closes: #98