### PR TITLE
poseidon-merkle: Bump to v0.10.0

### DIFF
--- a/poseidon-merkle/CHANGELOG.md
+++ b/poseidon-merkle/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-06-03
+
 ### Changed
 
 - Update `dusk-plonk` to v0.23
@@ -91,7 +93,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#58]: https://github.com/dusk-network/merkle/issues/58
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/merkle/compare/poseidon-merkle_v0.8.0...HEAD
+[Unreleased]: https://github.com/dusk-network/merkle/compare/poseidon-merkle_v0.10.0...HEAD
+[0.10.0]: https://github.com/dusk-network/merkle/compare/poseidon-merkle_v0.8.0...poseidon-merkle_v0.10.0
 [0.8.0]: https://github.com/dusk-network/merkle/compare/poseidon-merkle_v0.7.0...poseidon-merkle_v0.8.0
 [0.7.0]: https://github.com/dusk-network/merkle/compare/poseidon-merkle_v0.6.1...poseidon-merkle_v0.7.0
 [0.6.1]: https://github.com/dusk-network/merkle/compare/poseidon-merkle_v0.6.0...poseidon-merkle_v0.6.1

--- a/poseidon-merkle/Cargo.toml
+++ b/poseidon-merkle/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "poseidon-merkle"
 description = "Crate implementing Dusk Network's Merkle tree with the poseidon hash function"
-version = "0.9.0-rc.0"
+version = "0.10.0"
 
 categories = ["data-structures", "no-std"]
 keywords = ["tree", "merkle", "poseidon", "data", "structure"]


### PR DESCRIPTION
### Changed

- Update `dusk-plonk` to v0.23
- Update `dusk-poseidon` to v0.43
- Replace `dusk-bls12_381` with `dusk-curves` v0.2
- Add `bls-backend-dusk` and `bls-backend-blst` features for consumers to select the BLS12-381 backend
- Use the BLST backend in local and CI verification commands
- Update `dusk-merkle` to `v0.6.0-rc.0`
- Update to rust stable version 1.85, edition 2024