### PR TITLE
dusk-merkle: Handle inconsistent tree paths

### DIFF
--- a/dusk-merkle/CHANGELOG.md
+++ b/dusk-merkle/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Return `None` when recorded tree positions have missing paths [#110]
 - Reject out-of-range position values during `Opening::from_slice` deserialization
 - Fix `unsafe_op_in_unsafe_fn` warnings for edition 2024
 
@@ -119,6 +120,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix `CheckBytes` derivation in `Node` [#15]
 
 <!-- ISSUES -->
+[#110]: https://github.com/dusk-network/merkle/issues/110
 [#91]: https://github.com/dusk-network/merkle/issues/91
 [#73]: https://github.com/dusk-network/merkle/issues/73
 [#62]: https://github.com/dusk-network/merkle/issues/62

--- a/dusk-merkle/src/node.rs
+++ b/dusk-merkle/src/node.rs
@@ -74,6 +74,12 @@ where
         (child_index, child_pos)
     }
 
+    // Cache presence is not a durable inserted-leaf invariant for malformed
+    // archives: `item()` can lazily populate an item-less leaf.
+    pub(crate) fn has_cached_item(&self) -> bool {
+        self.item.borrow().is_some()
+    }
+
     pub(crate) fn insert(
         &mut self,
         height: usize,
@@ -98,40 +104,31 @@ where
         Self::insert(child, height + 1, child_pos, item);
     }
 
-    /// Returns the removed element, together with if there are any siblings
-    /// left in the branch.
-    ///
-    /// # Panics
-    /// If an element does not exist at the given position.
-    pub(crate) fn remove(&mut self, height: usize, position: u64) -> (T, bool) {
+    /// Returns the removed element, together with whether there are any
+    /// siblings left in the branch. Returns `None` if the path is incomplete.
+    pub(crate) fn remove(
+        &mut self,
+        height: usize,
+        position: u64,
+    ) -> Option<(T, bool)> {
         if height == H {
-            // unwrapping is ok since leaves are always filled
-            let item = self.item.take().unwrap();
-            return (item, false);
+            // This is fallible for a cold item-less leaf, but a lazily warmed
+            // cache cannot establish whether an archived leaf was inserted.
+            return self.item.take().map(|item| (item, false));
         }
-        self.item.replace(None);
 
         let (child_index, child_pos) = Self::child_location(height, position);
-
-        let child = self.children[child_index]
-            .as_mut()
-            .expect("There should be a child at this position");
+        let child = self.children.get_mut(child_index)?.as_mut()?;
         let (removed_item, child_has_children) =
-            Self::remove(child, height + 1, child_pos);
+            Self::remove(child, height + 1, child_pos)?;
 
+        self.item.replace(None);
         if !child_has_children {
             self.children[child_index] = None;
         }
 
-        let mut has_children = false;
-        for child in &self.children {
-            if child.is_some() {
-                has_children = true;
-                break;
-            }
-        }
-
-        (removed_item, has_children)
+        let has_children = self.children.iter().any(Option::is_some);
+        Some((removed_item, has_children))
     }
 }
 

--- a/dusk-merkle/src/opening.rs
+++ b/dusk-merkle/src/opening.rs
@@ -31,20 +31,19 @@ impl<T, const H: usize, const A: usize> Opening<T, H, A>
 where
     T: Aggregate<A> + Clone,
 {
-    /// # Panics
-    /// If the given `position` is not in the `tree`.
-    pub(crate) fn new(tree: &Tree<T, H, A>, position: u64) -> Self {
+    pub(crate) fn new(tree: &Tree<T, H, A>, position: u64) -> Option<Self> {
         let positions = [0; H];
         let branch = init_array(|_| init_array(|_| T::EMPTY_SUBTREE));
 
         let mut opening = Self {
-            root: tree.root.item().clone(),
+            root: T::EMPTY_SUBTREE,
             branch,
             positions,
         };
-        fill_opening(&mut opening, &tree.root, 0, position);
+        fill_opening(&mut opening, &tree.root, 0, position)?;
+        opening.root = tree.root.item().clone();
 
-        opening
+        Some(opening)
     }
 
     /// Returns the root of the opening.
@@ -189,20 +188,19 @@ fn fill_opening<T, const H: usize, const A: usize>(
     node: &Node<T, H, A>,
     height: usize,
     position: u64,
-) where
+) -> Option<()>
+where
     T: Aggregate<A> + Clone,
 {
     if height == H {
-        return;
+        return node.has_cached_item().then_some(());
     }
 
     let (child_index, child_pos) =
         Node::<T, H, A>::child_location(height, position);
-    let child = node.children[child_index]
-        .as_ref()
-        .expect("There should be a child at this position");
+    let child = node.children.get(child_index)?.as_ref()?;
 
-    fill_opening(opening, child, height + 1, child_pos);
+    fill_opening(opening, child, height + 1, child_pos)?;
 
     for i in 0..A {
         if let Some(child) = &node.children[i] {
@@ -210,6 +208,7 @@ fn fill_opening<T, const H: usize, const A: usize>(
         }
     }
     opening.positions[height] = child_index;
+    Some(())
 }
 
 #[cfg(test)]

--- a/dusk-merkle/src/tree.rs
+++ b/dusk-merkle/src/tree.rs
@@ -63,11 +63,11 @@ where
     /// Remove and return the item at the given `position` in the tree if it
     /// exists.
     pub fn remove(&mut self, position: u64) -> Option<T> {
-        if !self.positions.contains(&position) {
+        if !self.has_recorded_position(position) {
             return None;
         }
 
-        let (item, _) = self.root.remove(0, position);
+        let (item, _) = self.root.remove(0, position)?;
         self.positions.remove(&position);
 
         Some(item)
@@ -78,10 +78,16 @@ where
     where
         T: Clone,
     {
-        if !self.positions.contains(&position) {
+        if !self.has_recorded_position(position) {
             return None;
         }
-        Some(Opening::new(self, position))
+        Opening::new(self, position)
+    }
+
+    // Capacity must be checked before private path traversal: child indices
+    // are derived through a potentially truncating `u64` to `usize` cast.
+    fn has_recorded_position(&self, position: u64) -> bool {
+        position < self.capacity() && self.positions.contains(&position)
     }
 
     /// Returns a [`Walk`] through the tree, proceeding according to the
@@ -223,6 +229,69 @@ mod tests {
     fn tree_insertion_out_of_bounds() {
         let mut tree = SumTree::new();
         tree.insert(tree.capacity(), 42);
+    }
+
+    #[test]
+    fn inconsistent_tree_path_returns_none() {
+        let mut tree = SumTree::new();
+        let position = 5;
+        tree.insert(position, 42);
+
+        let (child_index, _) = Node::<u8, H, A>::child_location(0, position);
+        tree.root.children[child_index] = None;
+
+        let len = tree.len();
+        let root = *tree.root();
+
+        assert!(tree.opening(position).is_none());
+        assert!(tree.remove(position).is_none());
+        assert!(tree.contains(position));
+        assert_eq!(tree.len(), len);
+        assert_eq!(*tree.root(), root);
+    }
+
+    #[test]
+    fn inconsistent_tree_path_below_root_returns_none() {
+        let mut tree = SumTree::new();
+        let position = 5;
+        tree.insert(position, 42);
+
+        let (child_index, child_position) =
+            Node::<u8, H, A>::child_location(0, position);
+        let child = tree.root.children[child_index]
+            .as_mut()
+            .expect("The inserted item must populate the root child");
+        let (child_index, _) =
+            Node::<u8, H, A>::child_location(1, child_position);
+        child.children[child_index] = None;
+
+        let len = tree.len();
+        let root = *tree.root();
+
+        assert!(tree.opening(position).is_none());
+        assert!(tree.remove(position).is_none());
+        assert!(tree.contains(position));
+        assert_eq!(tree.len(), len);
+        assert_eq!(*tree.root(), root);
+    }
+
+    #[test]
+    fn out_of_bounds_tree_position_returns_none() {
+        let mut tree = SumTree::new();
+        tree.insert(0, 42);
+
+        let position = 1 << 34;
+        tree.positions.insert(position);
+
+        let len = tree.len();
+        let root = *tree.root();
+
+        assert!(!tree.has_recorded_position(position));
+        assert!(tree.opening(position).is_none());
+        assert!(tree.remove(position).is_none());
+        assert!(tree.contains(position));
+        assert_eq!(tree.len(), len);
+        assert_eq!(*tree.root(), root);
     }
 
     // create test tree for shrunken root:


### PR DESCRIPTION
## Summary

- make opening and removal traversal fallible when a recorded position has a missing root or mid-path node
- reject positions at or beyond capacity before target-dependent index conversion
- preserve recorded positions, length, and root when removal is rejected
- add regressions for missing paths, wasm32-like truncation, and no mutation

## Validation

- `make test`
- `make no-std`
- `make clippy`
- `make fmt CHECK=1`
- `make check`
- tree regressions with overflow checks enabled

## Compatibility and residual work

The public API and archive layout are unchanged, and valid tree operations retain their existing behavior. Semantic validation of archived paths, positions, and item-less leaves is intentionally deferred to #119; in particular, lazy cache population is not treated here as a durable archived-leaf invariant.

Refs #110