### PR TITLE
dusk-merkle: Reject out-of-range opening positions

### DIFF
--- a/dusk-merkle/CHANGELOG.md
+++ b/dusk-merkle/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Return `None` when recorded tree positions have missing paths [#110]
+- Return `false` when an opening contains an out-of-range position [#109]
 - Reject out-of-range position values during `Opening::from_slice` deserialization
 - Fix `unsafe_op_in_unsafe_fn` warnings for edition 2024
 
@@ -121,6 +122,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- ISSUES -->
 [#110]: https://github.com/dusk-network/merkle/issues/110
+[#109]: https://github.com/dusk-network/merkle/issues/109
 [#91]: https://github.com/dusk-network/merkle/issues/91
 [#73]: https://github.com/dusk-network/merkle/issues/73
 [#62]: https://github.com/dusk-network/merkle/issues/62

--- a/dusk-merkle/src/opening.rs
+++ b/dusk-merkle/src/opening.rs
@@ -73,9 +73,9 @@ where
             let level = &self.branch[h];
             let position = self.positions[h];
 
-            // if the computed item doesn't match the stored item at the given
-            // position, the opening is incorrect
-            if item != level[position] {
+            // Reject out-of-range positions and computed items that do not
+            // match the stored item at the given position.
+            if position >= A || item != level[position] {
                 return false;
             }
 
@@ -286,5 +286,20 @@ mod tests {
                 "The opening should *only* be for the item that was inserted at the given position"
             );
         }
+    }
+
+    #[test]
+    fn opening_verify_rejects_out_of_range_position() {
+        let mut tree = TestTree::new();
+        tree.insert(0, 'A');
+
+        let mut opening = tree
+            .opening(0)
+            .expect("There must be an opening for an existing item");
+        assert!(opening.verify('A'));
+
+        opening.positions[H - 1] = A;
+
+        assert!(!opening.verify('A'));
     }
 }


### PR DESCRIPTION
## Summary

- return `false` when an opening contains a stored path position outside the tree arity
- add focused regression coverage and document the fix

## Validation

- `make test`
- `make no-std`
- `make clippy`
- `make fmt CHECK=1`
- `make check`
- opening regression with overflow checks enabled

## Compatibility

The public API and archive layout are unchanged. Valid openings verify as before; malformed out-of-range positions are rejected instead of panicking.

Resolves #109