### PR TITLE
Revert dusk-curves integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,8 +40,6 @@ make clean         # Clean build artifacts
 
 Tests use `--release` because `poseidon-merkle` depends on `dusk-plonk` (via the `zk` feature) — debug builds take extremely long for PLONK proofs.
 
-The `poseidon-merkle` no-std build uses the BLST backend. Its Makefile sets `CC_thumbv6m_none_eabi=clang` and target C flags so the `blst` C dependency can cross-compile to `thumbv6m-none-eabi` without requiring `arm-none-eabi-gcc`.
-
 ## Feature Flags
 
 ### `dusk-merkle`
@@ -57,17 +55,13 @@ The `poseidon-merkle` no-std build uses the BLST backend. Its Makefile sets `CC_
 
 | Feature    | Description                                    | Default |
 |------------|------------------------------------------------|---------|
-| `bls-backend-dusk` | Select the Dusk BLS12-381 backend through `dusk-curves` | No |
-| `bls-backend-blst` | Select the blst BLS12-381 backend through `dusk-curves` | No |
 | `zk`       | PLONK circuit support via `dusk-plonk`        | No      |
-| `rkyv-impl`| rkyv serialization (enables on dusk-curves and dusk-merkle too) | No |
+| `rkyv-impl`| rkyv serialization (enables on bls12_381 and dusk-merkle too) | No |
 | `size_16`  | rkyv 16-bit pointer size (mutually exclusive) | No      |
 | `size_32`  | rkyv 32-bit pointer size (mutually exclusive) | No      |
 | `size_64`  | rkyv 64-bit pointer size (mutually exclusive) | No      |
 
-**Note:** The `size_*` features are mutually exclusive — `--all-features` will fail. Use specific feature combinations (e.g. `--features=rkyv-impl,size_32`). For `poseidon-merkle`, `rkyv-impl` forwards to `dusk-curves/rkyv-impl`, which uses rkyv size 32.
-
-**Note:** `poseidon-merkle` does not select a BLS12-381 backend by default. Consumers must enable exactly one of `bls-backend-dusk` or `bls-backend-blst`; local repo and CI commands use `bls-backend-blst`.
+**Note:** The `size_*` features are mutually exclusive — `--all-features` will fail. Use specific feature combinations (e.g. `--features=rkyv-impl,size_32`).
 
 ## Architecture
 
@@ -89,7 +83,7 @@ The tree is a **sparse** data structure — only populated leaves and their ance
 
 ### Key Dependencies
 
-- `dusk-curves` — BLS12-381 scalar field facade (leaf type for Poseidon tree; backend selected by consumer)
+- `dusk-bls12_381` — BLS12-381 scalar field (leaf type for Poseidon tree)
 - `dusk-poseidon` — Poseidon hash function
 - `dusk-plonk` — PLONK proving system (optional, `zk` feature)
 - `dusk-bytes` — Canonical byte serialization

--- a/Makefile
+++ b/Makefile
@@ -23,12 +23,10 @@ fmt: ## Format code (requires nightly)
 	@cargo +nightly fmt --all $(if $(CHECK),-- --check,)
 
 check: ## Run cargo check
-	@cargo check -p dusk-merkle
-	@cargo check -p poseidon-merkle --features=bls-backend-blst
+	@cargo check
 
 doc: ## Generate documentation
-	@cargo doc -p dusk-merkle --no-deps
-	@cargo doc -p poseidon-merkle --no-deps --features=bls-backend-blst
+	@cargo doc --no-deps
 
 clean: ## Clean build artifacts
 	@cargo clean

--- a/dusk-merkle/CHANGELOG.md
+++ b/dusk-merkle/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Replace `dusk-bls12_381` dev dependency with `dusk-curves` v0.2 using the BLST backend
+- Update `dusk-bls12_381` dev dependency to v0.14
 - Update to rust stable version 1.85, edition 2024
 
 ### Fixed

--- a/dusk-merkle/Cargo.toml
+++ b/dusk-merkle/Cargo.toml
@@ -23,7 +23,7 @@ bytecheck = { version = "0.6", optional = true, default-features = false }
 [dev-dependencies]
 blake3 = "1"
 rand = "0.8"
-dusk-curves = { version = "0.2", default-features = false, features = ["bls-backend-blst"] }
+dusk-bls12_381 = "0.14"
 ff = { version = "0.13", default-features = false }
 criterion = "0.3"
 

--- a/dusk-merkle/README.md
+++ b/dusk-merkle/README.md
@@ -82,20 +82,19 @@ cargo bench
 
 For the `poseidon` tree:
 ```shell
-cargo bench -p poseidon-merkle --features bls-backend-blst
+cargo bench -p poseidon-merkle
 ```
 
 For the opening proof creation in zero-knowledge:
 ```shell
-cargo bench -p poseidon-merkle --features bls-backend-blst,zk
+cargo bench -p poseidon-merkle --features zk
 ```
 
 ## Implementations
 
 A merkle tree using the poseidon hash function for aggregation and plonk to
 generate an opening proof in zero-knowledge can be found in the same workspace
-under 'poseidon-merkle'. Consumers of that crate must enable exactly one
-BLS12-381 backend feature, `bls-backend-dusk` or `bls-backend-blst`.
+under 'poseidon-merkle'.
 
 ## License
 

--- a/dusk-merkle/tests/serializable_opening.rs
+++ b/dusk-merkle/tests/serializable_opening.rs
@@ -6,8 +6,8 @@
 
 use std::cmp;
 
+use dusk_bls12_381::BlsScalar;
 use dusk_bytes::{DeserializableSlice, Error as BytesError, Serializable};
-use dusk_curves::bls12_381::BlsScalar;
 use dusk_merkle::{Aggregate, Opening, Tree};
 use ff::Field;
 use rand::rngs::StdRng;

--- a/poseidon-merkle/CHANGELOG.md
+++ b/poseidon-merkle/CHANGELOG.md
@@ -9,11 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update `dusk-plonk` to v0.23
-- Update `dusk-poseidon` to v0.43
-- Replace `dusk-bls12_381` with `dusk-curves` v0.2
-- Add `bls-backend-dusk` and `bls-backend-blst` features for consumers to select the BLS12-381 backend
-- Use the BLST backend in local and CI verification commands
+- Update `dusk-plonk` to `v0.22.0-rc.0`
+- Update `dusk-poseidon` to `v0.42.0-rc.0`
 - Update `dusk-merkle` to `v0.6.0-rc.0`
 - Update to rust stable version 1.85, edition 2024
 

--- a/poseidon-merkle/CHANGELOG.md
+++ b/poseidon-merkle/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.10.0] - 2026-06-03
-
 ### Changed
 
 - Update `dusk-plonk` to v0.23
@@ -93,8 +91,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#58]: https://github.com/dusk-network/merkle/issues/58
 
 <!-- VERSIONS -->
-[Unreleased]: https://github.com/dusk-network/merkle/compare/poseidon-merkle_v0.10.0...HEAD
-[0.10.0]: https://github.com/dusk-network/merkle/compare/poseidon-merkle_v0.8.0...poseidon-merkle_v0.10.0
+[Unreleased]: https://github.com/dusk-network/merkle/compare/poseidon-merkle_v0.8.0...HEAD
 [0.8.0]: https://github.com/dusk-network/merkle/compare/poseidon-merkle_v0.7.0...poseidon-merkle_v0.8.0
 [0.7.0]: https://github.com/dusk-network/merkle/compare/poseidon-merkle_v0.6.1...poseidon-merkle_v0.7.0
 [0.6.1]: https://github.com/dusk-network/merkle/compare/poseidon-merkle_v0.6.0...poseidon-merkle_v0.6.1

--- a/poseidon-merkle/Cargo.toml
+++ b/poseidon-merkle/Cargo.toml
@@ -15,15 +15,12 @@ edition = "2024"
 rust-version = "1.85"
 license = "MPL-2.0"
 
-[package.metadata.docs.rs]
-features = ["bls-backend-blst"]
-
 [dependencies]
 dusk-bytes = "0.1"
 dusk-merkle.workspace = true
-dusk-curves = { version = "0.2", default-features = false }
-dusk-poseidon = { version = "0.43", default-features = false }
-dusk-plonk = { version = "0.23", optional = true, default-features = false }
+dusk-poseidon = "0.42.0-rc.0"
+dusk-bls12_381 = { version = "0.14", default-features = false }
+dusk-plonk = { version = "0.22.0-rc.0", optional = true, default-features = false }
 rkyv = { version = "0.7", optional = true, default-features = false }
 bytecheck = { version = "0.6", optional = true, default-features = false }
 
@@ -33,18 +30,7 @@ criterion = "0.3"
 ff = { version = "0.13", default-features = false }
 
 [features]
-default = []
-bls-backend-blst = [
-    "dusk-curves/bls-backend-blst",
-    "dusk-poseidon/bls-backend-blst",
-    "dusk-plonk?/bls-backend-blst",
-]
-bls-backend-dusk = [
-    "dusk-curves/bls-backend-dusk",
-    "dusk-poseidon/bls-backend-dusk",
-    "dusk-plonk?/bls-backend-dusk",
-]
-zk = ["dep:dusk-plonk", "dusk-plonk/alloc", "dusk-poseidon/zk"]
+zk = ["dusk-plonk/alloc", "dusk-poseidon/zk"]
 size_16 = ["rkyv/size_16"]
 size_32 = ["rkyv/size_32"]
 size_64 = ["rkyv/size_64"]
@@ -53,7 +39,7 @@ rkyv-impl = [
     "rkyv/alloc",
     "rkyv",
     "bytecheck",
-    "dusk-curves/rkyv-impl",
+    "dusk-bls12_381/rkyv-impl",
     "dusk-merkle/rkyv-impl",
 ]
 

--- a/poseidon-merkle/Cargo.toml
+++ b/poseidon-merkle/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "poseidon-merkle"
 description = "Crate implementing Dusk Network's Merkle tree with the poseidon hash function"
-version = "0.10.0"
+version = "0.9.0-rc.0"
 
 categories = ["data-structures", "no-std"]
 keywords = ["tree", "merkle", "poseidon", "data", "structure"]

--- a/poseidon-merkle/Makefile
+++ b/poseidon-merkle/Makefile
@@ -2,18 +2,15 @@ help: ## Display this help screen
 	@grep -h -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
 		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-BLST_CC ?= clang
-BLST_CFLAGS ?= --target=thumbv6m-none-eabi -mthumb
-
 test: ## Run poseidon-merkle tests
-	@cargo test --release -p poseidon-merkle --features=bls-backend-blst,zk,rkyv-impl,size_32
+	@cargo test --release -p poseidon-merkle --features=zk,rkyv-impl,size_32
 
 no-std: ## Verify no_std compatibility on bare-metal target
 	@rustup target add thumbv6m-none-eabi
-	@CC_thumbv6m_none_eabi=$(BLST_CC) CFLAGS_thumbv6m_none_eabi="$(BLST_CFLAGS)" cargo build --release -p poseidon-merkle --no-default-features --features=bls-backend-blst --target thumbv6m-none-eabi
+	@cargo build --release -p poseidon-merkle --no-default-features --target thumbv6m-none-eabi
 
 clippy: ## Run clippy
-	@cargo clippy -p poseidon-merkle --features=bls-backend-blst,zk,rkyv-impl,size_32 -- -D warnings
-	@cargo clippy -p poseidon-merkle --no-default-features --features=bls-backend-blst -- -D warnings
+	@cargo clippy -p poseidon-merkle --features=zk,rkyv-impl,size_32 -- -D warnings
+	@cargo clippy -p poseidon-merkle --no-default-features -- -D warnings
 
 .PHONY: help test no-std clippy

--- a/poseidon-merkle/README.md
+++ b/poseidon-merkle/README.md
@@ -27,30 +27,16 @@ The type `Item<T>` has the aggregation of the `hash` part with the poseidon hash
 pre-defined and additionally allows for a custom data type with custom
 aggregation.
 
-## Features
-
-This crate does not select a BLS12-381 backend by default. Consumers must enable
-exactly one backend feature:
-
-- `bls-backend-dusk`
-- `bls-backend-blst`
-
-The selected backend is forwarded to `dusk-curves`, `dusk-poseidon`, and to
-`dusk-plonk` when the `zk` feature is enabled.
-
-The `rkyv-impl` feature forwards to `dusk-curves/rkyv-impl`, which uses rkyv
-size 32.
-
 ## Benchmarks
 
 There are benchmarks for the poseidon tree calculation available with
 ```shell
-cargo bench --features bls-backend-blst
+cargo bench
 ```
 
 and additional benchmarks for the opening proof generation with PLONK
 ```shell
-cargo bench --features bls-backend-blst,zk
+cargo bench --features zk
 ```
 
 This requires a nightly toolchain.

--- a/poseidon-merkle/benches/poseidon.rs
+++ b/poseidon-merkle/benches/poseidon.rs
@@ -5,7 +5,7 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 use criterion::{Criterion, black_box, criterion_group, criterion_main};
-use dusk_curves::bls12_381::BlsScalar;
+use dusk_bls12_381::BlsScalar;
 use dusk_poseidon::{Domain, Hash};
 use poseidon_merkle::{Item, Tree};
 use rand::{RngCore, SeedableRng};

--- a/poseidon-merkle/benches/zk.rs
+++ b/poseidon-merkle/benches/zk.rs
@@ -8,7 +8,6 @@
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use dusk_plonk::prelude::*;
-use dusk_poseidon::{Domain, Hash};
 use poseidon_merkle::zk::opening_gadget;
 use poseidon_merkle::{Item, Opening, Tree};
 use rand::rngs::StdRng;
@@ -17,16 +16,17 @@ use rand::{RngCore, SeedableRng};
 // set max circuit size to 2^13 gates
 const CAPACITY: usize = 16;
 
-// set height of the poseidon merkle tree
+// set height and arity of the poseidon merkle tree
 const HEIGHT: usize = 17;
+const ARITY: usize = 4;
 
-type PoseidonTree = Tree<(), HEIGHT>;
+type PoseidonTree = Tree<(), HEIGHT, ARITY>;
 type PoseidonItem = Item<()>;
 
 // Create a circuit for the opening
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 struct OpeningCircuit {
-    opening: Opening<(), HEIGHT>,
+    opening: Opening<(), HEIGHT, ARITY>,
     leaf: PoseidonItem,
 }
 
@@ -48,7 +48,10 @@ impl Default for OpeningCircuit {
 
 impl OpeningCircuit {
     /// Create a new OpeningCircuit
-    pub fn new(opening: Opening<(), HEIGHT>, leaf: PoseidonItem) -> Self {
+    pub fn new(
+        opening: Opening<(), HEIGHT, ARITY>,
+        leaf: PoseidonItem,
+    ) -> Self {
         Self { opening, leaf }
     }
 }
@@ -85,7 +88,7 @@ fn bench_zk(c: &mut Criterion) {
     for _ in 0..100 {
         let pos = rng.next_u64() % u32::MAX as u64;
         let leaf = PoseidonItem {
-            hash: Hash::digest(Domain::Other, &[pos.into()])[0],
+            hash: dusk_poseidon::sponge::hash(&[pos.into()]),
             data: (),
         };
         tree.insert(pos, leaf);
@@ -94,7 +97,7 @@ fn bench_zk(c: &mut Criterion) {
     // insert new leaf in the tree at random position to create opening
     let pos = rng.next_u64() % u32::MAX as u64;
     let leaf = PoseidonItem {
-        hash: Hash::digest(Domain::Other, &[pos.into()])[0],
+        hash: dusk_poseidon::sponge::hash(&[pos.into()]),
         data: (),
     };
     tree.insert(pos, leaf);

--- a/poseidon-merkle/src/lib.rs
+++ b/poseidon-merkle/src/lib.rs
@@ -11,26 +11,8 @@
 #[cfg(feature = "zk")]
 pub mod zk;
 
-#[cfg(all(feature = "bls-backend-dusk", feature = "bls-backend-blst"))]
-compile_error!(
-    "features 'bls-backend-dusk' and 'bls-backend-blst' are mutually exclusive"
-);
-
-#[cfg(not(any(feature = "bls-backend-dusk", feature = "bls-backend-blst")))]
-compile_error!(
-    "no BLS12-381 backend selected: enable either 'bls-backend-dusk' or 'bls-backend-blst'"
-);
-
-#[cfg(all(
-    feature = "rkyv-impl",
-    any(feature = "size_16", feature = "size_64")
-))]
-compile_error!(
-    "feature 'rkyv-impl' requires rkyv size 32 through 'dusk-curves/rkyv-impl'"
-);
-
+use dusk_bls12_381::BlsScalar;
 use dusk_bytes::Serializable;
-use dusk_curves::bls12_381::BlsScalar;
 use dusk_merkle::Aggregate;
 use dusk_poseidon::{Domain, Hash};
 
@@ -53,7 +35,7 @@ pub type Opening<T, const H: usize> = dusk_merkle::Opening<Item<T>, H, ARITY>;
 /// ```rust
 /// use std::cmp::{max, min};
 ///
-/// use dusk_curves::bls12_381::BlsScalar;
+/// use dusk_bls12_381::BlsScalar;
 /// use dusk_merkle::Aggregate;
 /// use dusk_poseidon::{Domain, Hash};
 /// use poseidon_merkle::{ARITY, Item, Tree as PoseidonTree};


### PR DESCRIPTION
## Summary

Reverts the `dusk-curves` migration (#107) and the release published on top of
it (#108 poseidon-merkle `0.10.0`). Those artifacts were withdrawn from
crates.io, but the code remained on `main`, forcing upcoming work onto a
diverged mainline. This returns `main` to its pre-curves state across both
workspace crates: `dusk-merkle` and `poseidon-merkle` are back on
`dusk-bls12_381` / `dusk-poseidon 0.42` / `dusk-plonk 0.22`, with the
`bls-backend-*` features removed.

Source revert only — no version bump, no publish. The tree is byte-identical to
the pre-curves commit `3416f48`.
