### PR TITLE
fix: use checked_sub in child_location under overflow-checks

### DIFF
--- a/dusk-merkle/CHANGELOG.md
+++ b/dusk-merkle/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Use `checked_sub` in `child_location` so tree insert does not panic under `overflow-checks` on wasm32 [#117]
 - Reject out-of-range position values during `Opening::from_slice` deserialization
 - Fix `unsafe_op_in_unsafe_fn` warnings for edition 2024
 

--- a/dusk-merkle/src/node.rs
+++ b/dusk-merkle/src/node.rs
@@ -63,7 +63,11 @@ where
     }
 
     pub(crate) fn child_location(height: usize, position: u64) -> (usize, u64) {
-        let child_cap = capacity(A as u64, H - height - 1);
+        let depth = match H.checked_sub(height).and_then(|d| d.checked_sub(1)) {
+            Some(d) => d,
+            None => panic!("child_location: invalid height {height} for tree height {H}"),
+        };
+        let child_cap = capacity(A as u64, depth);
 
         // Casting to a `usize` should be fine, since the index should be within
         // the `[0, A[` bound anyway.

--- a/dusk-merkle/src/tree.rs
+++ b/dusk-merkle/src/tree.rs
@@ -189,6 +189,18 @@ mod tests {
     }
 
     #[test]
+    fn tree_insert_h16_a4_at_root() {
+        const H16: usize = 16;
+        const A4: usize = 4;
+        type BigTree = Tree<u8, H16, A4>;
+
+        let mut tree = BigTree::new();
+        tree.insert(0, 1);
+
+        assert_eq!(tree.len(), 1);
+    }
+
+    #[test]
     fn tree_deletion() {
         let mut tree = SumTree::new();
 


### PR DESCRIPTION
## Summary

Fixes #117 — on `wasm32-unknown-unknown` release with `overflow-checks = true`, `Tree::insert` can panic inside `child_location` with `attempt to subtract with overflow` (`H - height - 1`). Downstream contract WASM built under forge-style profile inheritance (workspace-root `[profile.release] overflow-checks = true`) hits this on the first Merkle insert — e.g. Citadel `issue_license` ([citadel#147](https://github.com/dusk-network/citadel/issues/147)).

Replace unchecked subtract with `checked_sub` and an explicit invalid-height panic before `capacity`.

**Scope:** `dusk-merkle/src/node.rs` only.

## Test plan


| Test / check                                   | What it verifies                                                                                                                                                 |
| ---------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| Existing `tree::tests::`*                      | Regressions on default host test matrix (`tree_insertion`, `tree_deletion`, out-of-bounds panic, shrunken root, etc.)                                            |
| `tree_insert_h16_a4_at_root` (recommended add) | `Tree::<u8, 16, 4>::insert(0, …)` — Citadel / poseidon-merkle tree params used in repro                                                                          |
| `make test` / workspace default                | Full dusk-merkle + poseidon-merkle suite                                                                                                                         |
| Manual WASM repro (pre/post)                   | Workspace-root overflow-checks + `wasm32-unknown-unknown` release contract calling `insert(0, item)` under `VM::ephemeral()` — failure before fix, success after |


**Commands run locally:**

```bash
# Host regression (default profile)
cargo test -p dusk-merkle
make test

# Host with overflow-checks flag (belt-and-suspenders; may pass even pre-fix on happy path)
RUSTFLAGS="-C overflow-checks=yes" cargo test -p dusk-merkle tree::

# Optional: same flag on full workspace
RUSTFLAGS="-C overflow-checks=yes" make test
```

### Manual WASM repro (matches issue #117)

Workspace root only — member `[profile.release]` is ignored by Cargo:

```toml
[profile.release]
overflow-checks = true
```

Build contract WASM (`release`, `wasm32-unknown-unknown`) that calls `Tree::<(), 16>::insert(0, item)` once (or any consumer such as Citadel `license_contract` / agent-mandate `issue_license`). Deploy and call from a VM session.

```bash
CARGO_TARGET_DIR=target/contract cargo build \
  --release --features contract \
  --target wasm32-unknown-unknown -p <contract-crate>
```

**Note:** Host `cargo test` green does not disprove the bug — we reproduced on the WASM + VM path only. `wrapping_sub` in `child_location` did not fix WASM insert in our bisect; `checked_sub` did.