### PR TITLE
dusk-merkle: Validate archived tree invariants

### DIFF
--- a/dusk-merkle/CHANGELOG.md
+++ b/dusk-merkle/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Return `None` when recorded tree positions have missing paths [#110]
 - Reject archived openings with out-of-range positions during checked RKYV deserialization [#121]
 - Return `false` when an opening contains an out-of-range position [#109]
+- Reject archived trees with inconsistent positions, paths, or leaves [#110] [#119]
 - Reject out-of-range position values during `Opening::from_slice` deserialization
 - Fix `unsafe_op_in_unsafe_fn` warnings for edition 2024
 
@@ -123,6 +124,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- ISSUES -->
 [#121]: https://github.com/dusk-network/merkle/issues/121
+[#119]: https://github.com/dusk-network/merkle/issues/119
 [#110]: https://github.com/dusk-network/merkle/issues/110
 [#109]: https://github.com/dusk-network/merkle/issues/109
 [#91]: https://github.com/dusk-network/merkle/issues/91

--- a/dusk-merkle/src/node.rs
+++ b/dusk-merkle/src/node.rs
@@ -32,15 +32,18 @@ where
         }
     }
 
-    pub(crate) fn item(&self) -> Ref<'_, T> {
-        // a leaf will always have a computed item, so we never go into it
+    // `height` is this node's depth from the root: `0` for the root and `H`
+    // for a leaf.
+    pub(crate) fn item(&self, height: usize) -> Ref<'_, T> {
         if self.item.borrow().is_none() {
-            // compute our item, recursing into the children.
+            // Compute our item, recursing into the children.
             let empty_subtree = &T::EMPTY_SUBTREE;
             let mut item_refs = [empty_subtree; A];
 
             let child_items: [Option<Ref<T>>; A] = init_array(|i| {
-                self.children[i].as_ref().map(|item| item.item())
+                self.children[i]
+                    .as_ref()
+                    .and_then(|item| item.populated_item(height + 1))
             });
 
             let mut has_children = false;
@@ -58,8 +61,18 @@ where
             }
         }
 
-        // unwrapping is ok since we ensure it exists
+        // Unwrapping is safe because we ensure the item exists above.
         Ref::map(self.item.borrow(), |item| item.as_ref().unwrap())
+    }
+
+    // Unlike `item`, this does not allow lazy cache population to turn an
+    // item-less terminal node into an apparently populated leaf. `height` is
+    // the node's depth from the root, from `0` at the root to `H` at a leaf.
+    pub(crate) fn populated_item(&self, height: usize) -> Option<Ref<'_, T>> {
+        if height == H && !self.has_cached_item() {
+            return None;
+        }
+        Some(self.item(height))
     }
 
     pub(crate) fn child_location(height: usize, position: u64) -> (usize, u64) {
@@ -142,6 +155,7 @@ mod rkyv_impl {
     use core::cell::RefCell;
 
     use bytecheck::CheckBytes;
+    use rkyv::option::ArchivedOption;
     use rkyv::ser::Serializer;
     use rkyv::{
         Archive, Archived, Deserialize, Fallible, Resolver, Serialize,
@@ -163,6 +177,20 @@ mod rkyv_impl {
     pub struct NodeResolver<T: Archive, const H: usize, const A: usize> {
         item: Resolver<Option<T>>,
         children: Resolver<[Option<Box<Node<T, H, A>>>; A]>,
+    }
+
+    impl<T: Archive, const H: usize, const A: usize> ArchivedNode<T, H, A> {
+        pub(crate) fn has_item(&self) -> bool {
+            self.item.is_some()
+        }
+
+        pub(crate) fn child(&self, index: usize) -> Option<&Self> {
+            self.children.get(index)?.as_deref()
+        }
+
+        pub(crate) fn has_children(&self) -> bool {
+            self.children.iter().any(ArchivedOption::is_some)
+        }
     }
 
     impl<T, const H: usize, const A: usize> Archive for Node<T, H, A>

--- a/dusk-merkle/src/opening.rs
+++ b/dusk-merkle/src/opening.rs
@@ -139,7 +139,7 @@ where
             positions,
         };
         fill_opening(&mut opening, &tree.root, 0, position)?;
-        opening.root = tree.root.item().clone();
+        opening.root = tree.root.item(0).clone();
 
         Some(opening)
     }
@@ -302,7 +302,9 @@ where
 
     for i in 0..A {
         if let Some(child) = &node.children[i] {
-            opening.branch[height][i] = child.item().clone();
+            if let Some(item) = child.populated_item(height + 1) {
+                opening.branch[height][i] = item.clone();
+            }
         }
     }
     opening.positions[height] = child_index;

--- a/dusk-merkle/src/tree.rs
+++ b/dusk-merkle/src/tree.rs
@@ -13,8 +13,7 @@ use crate::{Aggregate, Node, Opening, Walk, capacity};
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(
     feature = "rkyv-impl",
-    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
-    archive_attr(derive(bytecheck::CheckBytes))
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
 )]
 pub struct Tree<T, const H: usize, const A: usize> {
     pub(crate) root: Node<T, H, A>,
@@ -106,7 +105,7 @@ where
 
     /// Get the root of the merkle tree.
     pub fn root(&self) -> Ref<'_, T> {
-        self.root.item()
+        self.root.item(0)
     }
 
     /// Returns the root of the smallest sub-tree that holds all the leaves.
@@ -130,7 +129,7 @@ where
                     // current height as the root and height of the smallest
                     // subtree
                     else {
-                        return (smallest_node.item(), height);
+                        return (smallest_node.item(H - height), height);
                     }
                 }
             }
@@ -159,6 +158,207 @@ where
     #[must_use]
     pub const fn capacity(&self) -> u64 {
         capacity(A as u64, H)
+    }
+}
+
+// Extend rkyv's structural byte checks with tree invariants without changing
+// the archived representation.
+#[cfg(feature = "rkyv-impl")]
+mod rkyv_impl {
+    use alloc::boxed::Box;
+    use alloc::collections::BTreeSet;
+    use core::{fmt, ptr};
+
+    use bytecheck::{CheckBytes, Error, StructCheckError};
+    use rkyv::{Archive, Archived};
+
+    use super::ArchivedTree;
+    use crate::Node;
+
+    #[derive(Debug)]
+    struct ArchiveInvariantError(&'static str);
+
+    impl fmt::Display for ArchiveInvariantError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str(self.0)
+        }
+    }
+
+    impl core::error::Error for ArchiveInvariantError {}
+
+    fn field_error(
+        field_name: &'static str,
+        error: impl Error,
+    ) -> StructCheckError {
+        StructCheckError {
+            field_name,
+            inner: Box::new(error),
+        }
+    }
+
+    fn invariant_error(message: &'static str) -> StructCheckError {
+        field_error("positions", ArchiveInvariantError(message))
+    }
+
+    fn checked_capacity<const H: usize, const A: usize>() -> Option<u64> {
+        if H == 0 || A == 0 {
+            return None;
+        }
+
+        let arity = u64::try_from(A).ok()?;
+        let height = u32::try_from(H).ok()?;
+        arity.checked_pow(height)
+    }
+
+    // The linear leaf-position match relies on `BTreeSet` iteration yielding
+    // ascending positions and index-ordered DFS visiting leaves in the same
+    // order.
+    fn validate_node<T, I, const H: usize, const A: usize>(
+        node: &Archived<Node<T, H, A>>,
+        height: usize,
+        position: u64,
+        capacity: u64,
+        positions: &mut I,
+    ) -> Result<(), ArchiveInvariantError>
+    where
+        T: Archive,
+        I: Iterator<Item = u64>,
+    {
+        if height == H {
+            if node.has_children() {
+                return Err(ArchiveInvariantError(
+                    "an archived node extends below the tree height",
+                ));
+            }
+            if !node.has_item() {
+                return Err(ArchiveInvariantError(
+                    "an archived leaf has no item",
+                ));
+            }
+            return match positions.next() {
+                Some(expected) if expected == position => Ok(()),
+                _ => Err(ArchiveInvariantError(
+                    "archived leaves and recorded positions do not match",
+                )),
+            };
+        }
+
+        let child_capacity = capacity
+            / u64::try_from(A).map_err(|_| {
+                ArchiveInvariantError("the archived tree arity exceeds u64")
+            })?;
+        let mut has_children = false;
+        for index in 0..A {
+            if let Some(child) = node.child(index) {
+                has_children = true;
+                let offset = u64::try_from(index)
+                    .ok()
+                    .and_then(|index| index.checked_mul(child_capacity))
+                    .and_then(|offset| position.checked_add(offset))
+                    .ok_or(ArchiveInvariantError(
+                        "an archived path exceeds the tree capacity",
+                    ))?;
+                validate_node(
+                    child,
+                    height + 1,
+                    offset,
+                    child_capacity,
+                    positions,
+                )?;
+            }
+        }
+
+        if !has_children && height != 0 {
+            return Err(ArchiveInvariantError(
+                "an archived path has no populated leaf",
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn validate_archive<T, const H: usize, const A: usize>(
+        tree: &ArchivedTree<T, H, A>,
+    ) -> Result<(), StructCheckError>
+    where
+        T: Archive,
+    {
+        let capacity = checked_capacity::<H, A>().ok_or_else(|| {
+            invariant_error(
+                "tree height and arity must be nonzero and fit in u64 capacity",
+            )
+        })?;
+
+        if tree.positions.iter().any(|position| *position >= capacity) {
+            return Err(invariant_error(
+                "an archived position is outside the tree capacity",
+            ));
+        }
+
+        let mut positions = tree.positions.iter().copied();
+        validate_node(&tree.root, 0, 0, capacity, &mut positions)
+            .map_err(|error| field_error("root", error))?;
+        if positions.next().is_some() {
+            return Err(invariant_error(
+                "archived leaves and recorded positions do not match",
+            ));
+        }
+
+        Ok(())
+    }
+
+    // Internal aggregate caches are deliberately outside this structural
+    // validation boundary. Deserialization preserves them as trusted local
+    // persistence data; callers that require leaf-derived aggregates must
+    // authenticate or rebuild them separately.
+    impl<C, T, const H: usize, const A: usize> CheckBytes<C>
+        for ArchivedTree<T, H, A>
+    where
+        C: ?Sized,
+        T: Archive,
+        Archived<Node<T, H, A>>: CheckBytes<C>,
+        Archived<BTreeSet<u64>>: CheckBytes<C>,
+    {
+        // Keep the derive-generated error type for API compatibility while
+        // extending the field checks with semantic tree validation.
+        type Error = StructCheckError;
+
+        unsafe fn check_bytes<'a>(
+            value: *const Self,
+            context: &mut C,
+        ) -> Result<&'a Self, Self::Error> {
+            // SAFETY: The caller guarantees that `value` is aligned and points
+            // to enough bytes for `Self`; each field validator checks its own
+            // archived representation and referenced data.
+            unsafe {
+                <Archived<Node<T, H, A>> as CheckBytes<C>>::check_bytes(
+                    ptr::addr_of!((*value).root),
+                    context,
+                )
+            }
+            .map_err(|error| field_error("root", error))?;
+
+            // SAFETY: This is the second field of the same caller-validated
+            // `ArchivedTree` allocation. Its validator checks all B-tree data
+            // before semantic validation reads it.
+            unsafe {
+                <Archived<BTreeSet<u64>> as CheckBytes<C>>::check_bytes(
+                    ptr::addr_of!((*value).positions),
+                    context,
+                )
+            }
+            .map_err(|error| field_error("positions", error))?;
+
+            // SAFETY: Both fields and all referenced archived data have been
+            // structurally validated above.
+            let tree = unsafe { &*value };
+            let Self {
+                root: _,
+                positions: _,
+            } = tree;
+            validate_archive(tree)?;
+            Ok(tree)
+        }
     }
 }
 
@@ -414,24 +614,314 @@ mod tests {
 
     #[cfg(feature = "rkyv-impl")]
     mod rkyv_impl {
-        use super::SumTree;
+        extern crate std;
+
+        use alloc::boxed::Box;
+        use alloc::string::ToString;
+        use alloc::vec::Vec;
+        use std::panic::{AssertUnwindSafe, catch_unwind};
+
+        use super::{A, H, SumTree};
+        use crate::{Aggregate, Node, Opening};
+
+        const POSITION: u64 = 5;
+
+        fn archive(tree: &SumTree) -> Vec<u8> {
+            rkyv::to_bytes::<_, 128>(tree)
+                .expect("Archiving a tree should succeed")
+                .to_vec()
+        }
+
+        fn assert_rejected_without_unwind(
+            case: &str,
+            tree: &SumTree,
+            expected_error: &str,
+        ) {
+            let tree_bytes = archive(tree);
+            let result = catch_unwind(AssertUnwindSafe(|| {
+                rkyv::from_bytes::<SumTree>(&tree_bytes)
+            }));
+
+            match result {
+                Ok(Err(error)) => assert!(
+                    error.to_string().contains(expected_error),
+                    "{case}: expected error containing {expected_error:?}, got {error}"
+                ),
+                Ok(Ok(_)) => panic!("{case}: malformed archive was accepted"),
+                Err(_) => panic!("{case}: archive rejection unwound"),
+            }
+        }
+
+        fn populated_tree() -> SumTree {
+            let mut tree = SumTree::new();
+            tree.insert(POSITION, 42);
+            tree
+        }
+
+        fn decode_without_unwind(case: &str, tree: &SumTree) -> SumTree {
+            let tree_bytes = archive(tree);
+            let result = catch_unwind(AssertUnwindSafe(|| {
+                rkyv::from_bytes::<SumTree>(&tree_bytes)
+            }));
+
+            match result {
+                Ok(Ok(tree)) => tree,
+                Ok(Err(error)) => {
+                    panic!(
+                        "{case}: structurally valid archive was rejected: {error}"
+                    )
+                }
+                Err(_) => panic!("{case}: checked deserialization unwound"),
+            }
+        }
+
+        fn node_at_height_mut(
+            tree: &mut SumTree,
+            target_height: usize,
+            position: u64,
+        ) -> &mut Node<u8, H, A> {
+            let mut node = &mut tree.root;
+            let mut child_position = position;
+            for height in 0..target_height {
+                let (child_index, next_position) =
+                    Node::<u8, H, A>::child_location(height, child_position);
+                node = node.children[child_index]
+                    .as_mut()
+                    .expect("The inserted items must populate the path");
+                child_position = next_position;
+            }
+            node
+        }
+
+        fn replace_leaf_with_itemless_node(
+            node: &mut Node<u8, H, A>,
+            height: usize,
+            position: u64,
+        ) {
+            let (child_index, child_position) =
+                Node::<u8, H, A>::child_location(height, position);
+            if height + 1 == H {
+                node.children[child_index] = Some(Box::new(Node::new()));
+                return;
+            }
+
+            let child = node.children[child_index]
+                .as_mut()
+                .expect("The inserted item must populate every path node");
+            replace_leaf_with_itemless_node(child, height + 1, child_position);
+        }
+
+        fn tree_with_itemless_leaf() -> SumTree {
+            let mut tree = populated_tree();
+            replace_leaf_with_itemless_node(&mut tree.root, 0, POSITION);
+            tree
+        }
 
         #[test]
-        fn serde() {
+        fn valid_tree_round_trip_and_operations() {
+            let tree = populated_tree();
+            let mut decoded = rkyv::from_bytes::<SumTree>(&archive(&tree))
+                .expect("Deserializing a valid tree should succeed");
+
+            assert_eq!(tree, decoded);
+            assert!(
+                decoded
+                    .opening(POSITION)
+                    .is_some_and(|opening| opening.verify(42))
+            );
+            assert_eq!(decoded.remove(POSITION), Some(42));
+
+            let round_trip = rkyv::from_bytes::<SumTree>(&archive(&decoded))
+                .expect("A valid modified tree should still round-trip");
+            assert_eq!(decoded, round_trip);
+        }
+
+        fn valid_two_leaf_tree() -> SumTree {
             let mut tree = SumTree::new();
+            tree.insert(4, 20);
+            tree.insert(5, 22);
+            tree
+        }
 
-            tree.insert(5, 42);
-            tree.insert(6, 42);
-            tree.insert(5, 42);
+        type OperationResults =
+            (u8, Option<Opening<u8, H, A>>, (u8, usize), Vec<u8>);
 
-            let tree_bytes = rkyv::to_bytes::<_, 128>(&tree)
-                .expect("Archiving a tree should succeed")
-                .to_vec();
+        fn operation_results_without_unwind(
+            case: &str,
+            tree: &SumTree,
+            position: u64,
+        ) -> OperationResults {
+            catch_unwind(AssertUnwindSafe(|| {
+                let root = *tree.root();
+                let opening = tree.opening(position);
+                let (smallest, height) = tree.smallest_subtree();
+                let smallest = (*smallest, height);
+                let walk = tree
+                    .walk(|item| *item <= 42)
+                    .map(|item| *item)
+                    .collect::<Vec<_>>();
+                (root, opening, smallest, walk)
+            }))
+            .unwrap_or_else(|_| {
+                panic!("{case}: decoded tree operation unwound")
+            })
+        }
 
-            let archived_tree = rkyv::from_bytes::<SumTree>(&tree_bytes)
-                .expect("Deserializing a tree should succeed");
+        #[test]
+        fn valid_cold_and_warmed_archives_preserve_cache_state() {
+            let cold = valid_two_leaf_tree();
+            let warmed = cold.clone();
+            let expected =
+                operation_results_without_unwind("valid tree", &warmed, 4);
 
-            assert_eq!(tree, archived_tree);
+            assert_eq!(expected.0, 42);
+            assert!(expected.1.is_some_and(|opening| {
+                *opening.root() == 42 && opening.verify(20)
+            }));
+            assert_eq!(expected.2, (42, 1));
+            assert_eq!(expected.3, [20, 22]);
+
+            for (case, tree) in [
+                ("valid cold archive", &cold),
+                ("valid warmed archive", &warmed),
+            ] {
+                let decoded = decode_without_unwind(case, tree);
+                assert_eq!(
+                    decoded.root.has_cached_item(),
+                    tree.root.has_cached_item(),
+                    "{case}: deserialization must preserve cache state"
+                );
+                assert_eq!(
+                    operation_results_without_unwind(case, &decoded, 4),
+                    expected
+                );
+            }
+        }
+
+        #[test]
+        fn archived_node_below_tree_height_is_rejected() {
+            let mut tree = populated_tree();
+            let leaf = node_at_height_mut(&mut tree, H, POSITION);
+            leaf.children[0] = Some(Box::new(Node::new()));
+
+            assert_rejected_without_unwind(
+                "node below tree height",
+                &tree,
+                "an archived node extends below the tree height",
+            );
+        }
+
+        #[test]
+        fn itemless_archived_leaf_is_rejected() {
+            assert_rejected_without_unwind(
+                "item-less leaf",
+                &tree_with_itemless_leaf(),
+                "an archived leaf has no item",
+            );
+        }
+
+        #[test]
+        fn itemless_archived_leaf_is_rejected_after_cache_warming() {
+            let mut tree = tree_with_itemless_leaf();
+
+            assert_eq!(*tree.root(), u8::EMPTY_SUBTREE);
+            let (smallest, height) = tree.smallest_subtree();
+            assert_eq!(*smallest, u8::EMPTY_SUBTREE);
+            assert_eq!(height, 1);
+            drop(smallest);
+            assert!(tree.opening(POSITION).is_none());
+            assert!(tree.walk(|_| true).next().is_none());
+            assert!(tree.remove(POSITION).is_none());
+
+            assert_rejected_without_unwind(
+                "warmed item-less leaf",
+                &tree,
+                "an archived leaf has no item",
+            );
+        }
+
+        #[test]
+        fn itemless_sibling_is_rejected_after_opening_cache_warming() {
+            let mut tree = valid_two_leaf_tree();
+            replace_leaf_with_itemless_node(&mut tree.root, 0, POSITION);
+
+            let opening = tree
+                .opening(4)
+                .expect("the populated sibling must have an opening");
+            assert!(opening.verify(20));
+            assert!(tree.remove(POSITION).is_none());
+
+            assert_rejected_without_unwind(
+                "item-less sibling warmed by opening",
+                &tree,
+                "an archived leaf has no item",
+            );
+        }
+
+        #[test]
+        fn inconsistent_archives_are_rejected() {
+            let mut missing_root = populated_tree();
+            let (child_index, _) =
+                Node::<u8, H, A>::child_location(0, POSITION);
+            missing_root.root.children[child_index] = None;
+
+            let mut missing_mid = populated_tree();
+            let (child_index, child_position) =
+                Node::<u8, H, A>::child_location(0, POSITION);
+            let child = missing_mid.root.children[child_index]
+                .as_mut()
+                .expect("The inserted item must populate the root child");
+            let (child_index, _) =
+                Node::<u8, H, A>::child_location(1, child_position);
+            child.children[child_index] = None;
+
+            let mut out_of_capacity = populated_tree();
+            out_of_capacity.positions.insert(1 << 34);
+
+            let mut unrecorded = populated_tree();
+            unrecorded.positions.remove(&POSITION);
+
+            let mut wrong_position = populated_tree();
+            wrong_position.positions.remove(&POSITION);
+            wrong_position.positions.insert(4);
+
+            let mut dangling = SumTree::new();
+            dangling.root.children[0] = Some(Box::new(Node::new()));
+
+            for (case, tree, expected_error) in [
+                (
+                    "missing root path",
+                    missing_root,
+                    "archived leaves and recorded positions do not match",
+                ),
+                (
+                    "missing mid-path",
+                    missing_mid,
+                    "an archived path has no populated leaf",
+                ),
+                (
+                    "out-of-capacity position",
+                    out_of_capacity,
+                    "an archived position is outside the tree capacity",
+                ),
+                (
+                    "unrecorded leaf",
+                    unrecorded,
+                    "archived leaves and recorded positions do not match",
+                ),
+                (
+                    "wrong recorded position",
+                    wrong_position,
+                    "archived leaves and recorded positions do not match",
+                ),
+                (
+                    "path without a leaf",
+                    dangling,
+                    "an archived path has no populated leaf",
+                ),
+            ] {
+                assert_rejected_without_unwind(case, &tree, expected_error);
+            }
         }
     }
 }

--- a/dusk-merkle/src/walk.rs
+++ b/dusk-merkle/src/walk.rs
@@ -50,7 +50,9 @@ where
             for i in *index..A {
                 *index = i + 1;
                 if let Some(leaf) = &node.children[i] {
-                    let leaf = leaf.item();
+                    let Some(leaf) = leaf.populated_item(h + 1) else {
+                        continue;
+                    };
                     if (self.walker)(&*leaf) {
                         return Some(leaf);
                     }
@@ -71,7 +73,7 @@ where
                 self.indices[h] = i;
                 if let Some(child) = &node.children[i] {
                     let child = child.as_ref();
-                    if (self.walker)(&*child.item()) {
+                    if (self.walker)(&*child.item(h + 1)) {
                         self.path[h] = Some(child);
                         break;
                     }
@@ -94,7 +96,7 @@ where
 
                 if let Some(child) = &node.children[i] {
                     let child = child.as_ref();
-                    if (self.walker)(&*child.item()) {
+                    if (self.walker)(&*child.item(h + 1)) {
                         self.path[h] = Some(child);
                         if let Some(item) = self.advance(child, h + 1) {
                             return Some(item);


### PR DESCRIPTION
## Summary

- validate archived positions against tree capacity and complete populated paths
- reject item-less leaves, missing or dangling paths, unmatched positions, and ordinary over-height structures
- prevent cache warming from making an item-less terminal node appear populated
- preserve valid archived aggregate caches and the existing post-restart performance model
- add no-unwind regressions for the covered structural inconsistencies

## Validation

- `make test`
- `make no-std`
- `make cq`
- `make check`
- `make doc`
- RKYV release tests for `size_16`, `size_32`, and `size_64` in both crates
- mutation checks for item-less leaf rejection and warmed-cache preservation
- `git diff --check`

## Performance

Checked decoding performs a hash-free linear structural pass. It does not recompute Merkle aggregates. Valid warmed caches survive deserialization, so the first root read after restart retains the previous cached behavior.

## Compatibility

The public API, archived fields, field order, `Archive`/`Serialize` layout, and `CheckBytes` error type are unchanged. Valid cold and warmed archives preserve their cache state across deserialization.

## Trust boundary

This is structural validation, not persisted-state authentication. Internal aggregate caches remain trusted local persistence data and are deliberately not checked against the leaves. Consumers that require leaf-derived integrity must authenticate or rebuild those aggregates at a stronger boundary.

## Known follow-up

Ordinary `H + 1` height violations complete structural validation and are rejected semantically. Generic RKYV structural validation recurses before that semantic check; bounding attacker-controlled recursive depth is tracked in #123.

Resolves #110
Resolves #119