### PR TITLE
Benchmark decoded tree recomputation

### DIFF
--- a/dusk-merkle/CHANGELOG.md
+++ b/dusk-merkle/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reject archived openings with out-of-range positions during checked RKYV deserialization [#121]
 - Return `false` when an opening contains an out-of-range position [#109]
 - Reject archived trees with inconsistent positions, paths, or leaves [#110] [#119]
+- Discard archived internal aggregate caches during tree deserialization [#119]
 - Reject out-of-range position values during `Opening::from_slice` deserialization
 - Fix `unsafe_op_in_unsafe_fn` warnings for edition 2024
 

--- a/dusk-merkle/CHANGELOG.md
+++ b/dusk-merkle/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Benchmark cold decoded-tree root recomputation against warmed dirty paths [#125]
+
 ### Changed
 
 - Update `dusk-bls12_381` dev dependency to v0.14
@@ -124,6 +128,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix `CheckBytes` derivation in `Node` [#15]
 
 <!-- ISSUES -->
+[#125]: https://github.com/dusk-network/merkle/issues/125
 [#121]: https://github.com/dusk-network/merkle/issues/121
 [#119]: https://github.com/dusk-network/merkle/issues/119
 [#110]: https://github.com/dusk-network/merkle/issues/110

--- a/dusk-merkle/CHANGELOG.md
+++ b/dusk-merkle/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Return `None` when recorded tree positions have missing paths [#110]
 - Reject archived openings with out-of-range positions during checked RKYV deserialization [#121]
 - Return `false` when an opening contains an out-of-range position [#109]
+- Reject archived trees with inconsistent positions, paths, or leaves [#110] [#119]
 - Reject out-of-range position values during `Opening::from_slice` deserialization
 - Fix `unsafe_op_in_unsafe_fn` warnings for edition 2024
 
@@ -123,6 +124,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- ISSUES -->
 [#121]: https://github.com/dusk-network/merkle/issues/121
+[#119]: https://github.com/dusk-network/merkle/issues/119
 [#110]: https://github.com/dusk-network/merkle/issues/110
 [#109]: https://github.com/dusk-network/merkle/issues/109
 [#91]: https://github.com/dusk-network/merkle/issues/91

--- a/dusk-merkle/README.md
+++ b/dusk-merkle/README.md
@@ -90,6 +90,41 @@ For the opening proof creation in zero-knowledge:
 cargo bench -p poseidon-merkle --features zk
 ```
 
+To compare the first root read after checked RKYV deserialization with a warmed
+tree after one or four leaf updates:
+```shell
+cargo bench -p dusk-merkle --bench blake3 \
+  --features rkyv-impl,size_32 -- blake3_first_root
+```
+The benchmark times `root()` separately from decode and also reports the
+combined decode-and-first-root cost. Tree construction, checked decode for the
+root-only case, leaf updates, and destruction are outside the timed operation.
+
+Large wasm64 page trees with 10, 50, and 100 GiB of densely packed or scattered
+populated pages can be measured separately using:
+```shell
+cargo bench -p dusk-merkle --bench blake3 \
+  --features rkyv-impl,size_32 -- blake3_wasm64_first_root
+```
+This benchmark materializes only the page hashes and Merkle nodes, not the
+corresponding contract-memory bytes.
+
+The cold-root cost follows the number and distribution of populated pages, not
+only the declared memory length. Widely scattered pages share fewer internal
+nodes than densely packed pages and can make the first root after decoding
+substantially more expensive. Large wasm64 users should measure their expected
+occupancy: a 100 GiB scenario can take hundreds of milliseconds to rebuild on
+current desktop hardware when its pages are spread across the address space.
+
+## Checked RKYV deserialization
+
+With the `rkyv-impl` feature, checked tree deserialization deliberately discards
+all archived internal aggregate caches. Structural validation establishes the
+shape, leaves, and recorded positions of the tree, but cannot establish that an
+arbitrary cached aggregate was derived from those leaves. The first aggregate
+read therefore recomputes the populated internal nodes from leaf values; later
+reads use the lazily rebuilt caches until an update dirties their paths.
+
 ## Implementations
 
 A merkle tree using the poseidon hash function for aggregation and plonk to

--- a/dusk-merkle/benches/blake3.rs
+++ b/dusk-merkle/benches/blake3.rs
@@ -6,6 +6,8 @@
 
 use blake3::{Hash as Blake3Hash, Hasher};
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+#[cfg(feature = "rkyv-impl")]
+use criterion::{SamplingMode, black_box};
 use dusk_merkle::{Aggregate, Tree};
 use rand::rngs::StdRng;
 use rand::{RngCore, SeedableRng};
@@ -13,6 +15,11 @@ use rand::{RngCore, SeedableRng};
 const EMPTY_HASH: Item = Item([0; 32]);
 
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(
+    feature = "rkyv-impl",
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
+    archive_attr(derive(bytecheck::CheckBytes))
+)]
 pub struct Item([u8; 32]);
 
 impl From<Blake3Hash> for Item {
@@ -44,6 +51,12 @@ const H: usize = 32;
 const A: usize = 2;
 
 type Blake3Tree = Tree<Item, H, A>;
+// Matches Piecrust's 32-bit memory page-tree shape (65,536-page capacity).
+#[cfg(feature = "rkyv-impl")]
+type DecodedBlake3Tree = Tree<Item, 8, 4>;
+// Matches Piecrust's 64-bit memory page-tree shape.
+#[cfg(feature = "rkyv-impl")]
+type DecodedBlake3Tree64 = Tree<Item, 13, 4>;
 
 const NS: &[u64] = &[10, 100, 1000, 10000];
 
@@ -84,6 +97,310 @@ fn bench_blake3_root(c: &mut Criterion) {
     }
 }
 
+#[cfg(feature = "rkyv-impl")]
+#[derive(Clone, Copy)]
+enum Occupancy {
+    Dense,
+    Sparse,
+}
+
+#[cfg(feature = "rkyv-impl")]
+#[derive(Clone, Copy)]
+struct Scenario {
+    name: &'static str,
+    leaves: u64,
+    occupancy: Occupancy,
+}
+
+#[cfg(feature = "rkyv-impl")]
+const FIRST_ROOT_SCENARIOS: &[Scenario] = &[
+    Scenario {
+        name: "sparse_64",
+        leaves: 64,
+        occupancy: Occupancy::Sparse,
+    },
+    Scenario {
+        name: "sparse_4096",
+        leaves: 4096,
+        occupancy: Occupancy::Sparse,
+    },
+    Scenario {
+        name: "dense_4096",
+        leaves: 4096,
+        occupancy: Occupancy::Dense,
+    },
+    Scenario {
+        name: "dense_65536",
+        leaves: 65536,
+        occupancy: Occupancy::Dense,
+    },
+];
+
+#[cfg(feature = "rkyv-impl")]
+const PAGES_PER_GIB: u64 = (1 << 30) / (64 << 10);
+
+#[cfg(feature = "rkyv-impl")]
+const WASM64_FIRST_ROOT_SCENARIOS: &[Scenario] = &[
+    Scenario {
+        name: "dense_10_gib",
+        leaves: 10 * PAGES_PER_GIB,
+        occupancy: Occupancy::Dense,
+    },
+    Scenario {
+        name: "scattered_10_gib",
+        leaves: 10 * PAGES_PER_GIB,
+        occupancy: Occupancy::Sparse,
+    },
+    Scenario {
+        name: "dense_50_gib",
+        leaves: 50 * PAGES_PER_GIB,
+        occupancy: Occupancy::Dense,
+    },
+    Scenario {
+        name: "scattered_50_gib",
+        leaves: 50 * PAGES_PER_GIB,
+        occupancy: Occupancy::Sparse,
+    },
+    Scenario {
+        name: "dense_100_gib",
+        leaves: 100 * PAGES_PER_GIB,
+        occupancy: Occupancy::Dense,
+    },
+    Scenario {
+        name: "scattered_100_gib",
+        leaves: 100 * PAGES_PER_GIB,
+        occupancy: Occupancy::Sparse,
+    },
+];
+
+#[cfg(feature = "rkyv-impl")]
+fn scenario_position<const H: usize>(scenario: Scenario, index: u64) -> u64 {
+    match scenario.occupancy {
+        Occupancy::Dense => index,
+        // The odd multiplier is a permutation modulo the power-of-two tree
+        // capacity, so positions are deterministic, unique, and spread out.
+        Occupancy::Sparse => {
+            let capacity = 1u64 << (2 * H);
+            index.wrapping_mul(0x9e37_79b9) & (capacity - 1)
+        }
+    }
+}
+
+#[cfg(feature = "rkyv-impl")]
+fn scenario_item(position: u64, generation: u64) -> Item {
+    let mut bytes = [0u8; 32];
+    bytes[..8].copy_from_slice(&position.to_le_bytes());
+    bytes[8..16].copy_from_slice(&generation.to_le_bytes());
+    Hasher::new().update(&bytes).finalize().into()
+}
+
+#[cfg(feature = "rkyv-impl")]
+fn scenario_tree<const H: usize>(scenario: Scenario) -> Tree<Item, H, 4> {
+    let mut tree = Tree::new();
+    for index in 0..scenario.leaves {
+        let position = scenario_position::<H>(scenario, index);
+        tree.insert(position, scenario_item(position, 0));
+    }
+    assert_eq!(
+        tree.len(),
+        scenario.leaves,
+        "scenario positions must be unique"
+    );
+    tree
+}
+
+#[cfg(feature = "rkyv-impl")]
+fn update_tree<const H: usize>(
+    tree: &mut Tree<Item, H, 4>,
+    scenario: Scenario,
+    update_count: u64,
+    generation: u64,
+) {
+    let stride = scenario.leaves / update_count;
+    for update in 0..update_count {
+        let index = update * stride;
+        let position = scenario_position::<H>(scenario, index);
+        tree.insert(position, scenario_item(position, generation));
+    }
+}
+
+#[cfg(feature = "rkyv-impl")]
+fn bench_blake3_first_root(c: &mut Criterion) {
+    use std::time::{Duration, Instant};
+
+    let mut group = c.benchmark_group("blake3_first_root");
+    group
+        .sample_size(10)
+        .warm_up_time(Duration::from_secs(1))
+        .measurement_time(Duration::from_secs(4));
+
+    for &scenario in FIRST_ROOT_SCENARIOS {
+        let base = scenario_tree::<8>(scenario);
+        let warmed_root = *base.root();
+
+        let mut dirty = base.clone();
+        update_tree::<8>(&mut dirty, scenario, 1, 1);
+        let dirty_root = *dirty.root();
+        assert_ne!(warmed_root, dirty_root, "the update must change the root");
+        let archive = rkyv::to_bytes::<_, 4096>(&dirty)
+            .expect("scenario tree archiving must succeed");
+        let decoded = rkyv::from_bytes::<DecodedBlake3Tree>(&archive)
+            .expect("scenario tree checked deserialization must succeed");
+        let decoded_root = *decoded.root();
+        assert_eq!(
+            decoded_root, dirty_root,
+            "both paths must compute the same root"
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new(scenario.name, "cold_decoded"),
+            &scenario,
+            |b, _| {
+                b.iter_custom(|iterations| {
+                    let mut measured = Duration::ZERO;
+                    for _ in 0..iterations {
+                        // Checked decode is setup: every timed root receives a
+                        // fresh tree whose internal caches were discarded.
+                        let tree =
+                            rkyv::from_bytes::<DecodedBlake3Tree>(&archive)
+                                .expect("checked deserialization must succeed");
+                        let start = Instant::now();
+                        black_box(*tree.root());
+                        measured += start.elapsed();
+                    }
+                    measured
+                });
+            },
+        );
+
+        for update_count in [1, 4] {
+            group.bench_with_input(
+                BenchmarkId::new(
+                    scenario.name,
+                    format!("warm_dirty_{update_count}"),
+                ),
+                &scenario,
+                |b, &scenario| {
+                    let mut tree = scenario_tree::<8>(scenario);
+                    black_box(*tree.root());
+                    let mut generation = 1;
+                    b.iter_custom(|iterations| {
+                        let mut measured = Duration::ZERO;
+                        for _ in 0..iterations {
+                            // Updating is setup. The timer covers only root
+                            // recomputation along the newly dirtied paths.
+                            update_tree::<8>(
+                                &mut tree,
+                                scenario,
+                                update_count,
+                                generation,
+                            );
+                            generation += 1;
+                            let start = Instant::now();
+                            black_box(*tree.root());
+                            measured += start.elapsed();
+                        }
+                        measured
+                    });
+                },
+            );
+        }
+
+        group.bench_with_input(
+            BenchmarkId::new(scenario.name, "decode_and_first_root"),
+            &scenario,
+            |b, _| {
+                b.iter_custom(|iterations| {
+                    let mut measured = Duration::ZERO;
+                    for _ in 0..iterations {
+                        let start = Instant::now();
+                        let tree =
+                            rkyv::from_bytes::<DecodedBlake3Tree>(&archive)
+                                .expect("checked deserialization must succeed");
+                        black_box(*tree.root());
+                        measured += start.elapsed();
+                    }
+                    measured
+                });
+            },
+        );
+    }
+}
+
+#[cfg(feature = "rkyv-impl")]
+fn bench_blake3_wasm64_first_root(c: &mut Criterion) {
+    use std::time::{Duration, Instant};
+
+    let mut group = c.benchmark_group("blake3_wasm64_first_root");
+    group
+        .sample_size(10)
+        .sampling_mode(SamplingMode::Flat)
+        .warm_up_time(Duration::from_millis(250))
+        .measurement_time(Duration::from_secs(2));
+
+    for &scenario in WASM64_FIRST_ROOT_SCENARIOS {
+        // The benchmark materializes page hashes and tree nodes, not the
+        // corresponding 10-100 GiB of contract memory.
+        let mut tree = scenario_tree::<13>(scenario);
+        let warmed_root = *tree.root();
+        update_tree::<13>(&mut tree, scenario, 1, 1);
+        let dirty_root = *tree.root();
+        assert_ne!(warmed_root, dirty_root, "the update must change the root");
+        let archive = rkyv::to_bytes::<_, 4096>(&tree)
+            .expect("scenario tree archiving must succeed");
+        drop(tree);
+
+        let decoded = rkyv::from_bytes::<DecodedBlake3Tree64>(&archive)
+            .expect("scenario tree checked deserialization must succeed");
+        assert_eq!(
+            *decoded.root(),
+            dirty_root,
+            "both paths must compute the same root"
+        );
+        drop(decoded);
+
+        group.bench_with_input(
+            BenchmarkId::new(scenario.name, "cold_decoded"),
+            &scenario,
+            |b, _| {
+                b.iter_custom(|iterations| {
+                    let mut measured = Duration::ZERO;
+                    for _ in 0..iterations {
+                        // Decode remains setup so this isolates the cache
+                        // reconstruction caused by the first root read.
+                        let tree =
+                            rkyv::from_bytes::<DecodedBlake3Tree64>(&archive)
+                                .expect("checked deserialization must succeed");
+                        let start = Instant::now();
+                        black_box(*tree.root());
+                        measured += start.elapsed();
+                    }
+                    measured
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new(scenario.name, "decode_and_first_root"),
+            &scenario,
+            |b, _| {
+                b.iter_custom(|iterations| {
+                    let mut measured = Duration::ZERO;
+                    for _ in 0..iterations {
+                        let start = Instant::now();
+                        let tree =
+                            rkyv::from_bytes::<DecodedBlake3Tree64>(&archive)
+                                .expect("checked deserialization must succeed");
+                        black_box(*tree.root());
+                        measured += start.elapsed();
+                    }
+                    measured
+                });
+            },
+        );
+    }
+}
+
 fn insert_random_n<Rng: RngCore>(rng: &mut Rng, tree: &mut Blake3Tree, n: u64) {
     let cap = tree.capacity();
 
@@ -99,5 +416,14 @@ fn insert_random_n<Rng: RngCore>(rng: &mut Rng, tree: &mut Blake3Tree, n: u64) {
     }
 }
 
+#[cfg(feature = "rkyv-impl")]
+criterion_group!(
+    benches,
+    bench_blake3_insert,
+    bench_blake3_root,
+    bench_blake3_first_root,
+    bench_blake3_wasm64_first_root
+);
+#[cfg(not(feature = "rkyv-impl"))]
 criterion_group!(benches, bench_blake3_insert, bench_blake3_root);
 criterion_main!(benches);

--- a/dusk-merkle/src/node.rs
+++ b/dusk-merkle/src/node.rs
@@ -46,6 +46,8 @@ where
         }
     }
 
+    // `height` is this node's depth from the root: `0` for the root and `H`
+    // for a leaf.
     pub(crate) fn item(&self, height: usize) -> Ref<'_, T> {
         if self.item.borrow().is_none() {
             // Compute our item, recursing into the children.
@@ -78,7 +80,8 @@ where
     }
 
     // Unlike `item`, this does not allow lazy cache population to turn an
-    // item-less terminal node into an apparently populated leaf.
+    // item-less terminal node into an apparently populated leaf. `height` is
+    // the node's depth from the root, from `0` at the root to `H` at a leaf.
     pub(crate) fn populated_item(&self, height: usize) -> Option<Ref<'_, T>> {
         if height == H && !self.has_cached_item() {
             return None;
@@ -171,6 +174,7 @@ mod rkyv_impl {
     use core::cell::RefCell;
 
     use bytecheck::CheckBytes;
+    use rkyv::option::ArchivedOption;
     use rkyv::ser::Serializer;
     use rkyv::{
         Archive, Archived, Deserialize, Fallible, Resolver, Serialize,
@@ -204,9 +208,7 @@ mod rkyv_impl {
         }
 
         pub(crate) fn has_children(&self) -> bool {
-            self.children
-                .iter()
-                .any(rkyv::option::ArchivedOption::is_some)
+            self.children.iter().any(ArchivedOption::is_some)
         }
     }
 

--- a/dusk-merkle/src/node.rs
+++ b/dusk-merkle/src/node.rs
@@ -16,6 +16,20 @@ pub struct Node<T, const H: usize, const A: usize> {
     pub(crate) children: [Option<Box<Node<T, H, A>>>; A],
 }
 
+#[cfg(feature = "rkyv-impl")]
+impl<T, const H: usize, const A: usize> Node<T, H, A> {
+    pub(crate) fn clear_internal_caches(&self, height: usize) {
+        if height == H {
+            return;
+        }
+
+        self.item.replace(None);
+        for child in self.children.iter().flatten() {
+            child.clear_internal_caches(height + 1);
+        }
+    }
+}
+
 impl<T, const H: usize, const A: usize> Node<T, H, A>
 where
     T: Aggregate<A>,
@@ -88,6 +102,11 @@ where
     // archives: `item()` can lazily populate an item-less leaf.
     pub(crate) fn has_cached_item(&self) -> bool {
         self.item.borrow().is_some()
+    }
+
+    #[cfg(all(test, feature = "rkyv-impl"))]
+    pub(crate) fn replace_cached_item(&self, item: Option<T>) {
+        self.item.replace(item);
     }
 
     pub(crate) fn insert(

--- a/dusk-merkle/src/node.rs
+++ b/dusk-merkle/src/node.rs
@@ -32,15 +32,16 @@ where
         }
     }
 
-    pub(crate) fn item(&self) -> Ref<'_, T> {
-        // a leaf will always have a computed item, so we never go into it
+    pub(crate) fn item(&self, height: usize) -> Ref<'_, T> {
         if self.item.borrow().is_none() {
-            // compute our item, recursing into the children.
+            // Compute our item, recursing into the children.
             let empty_subtree = &T::EMPTY_SUBTREE;
             let mut item_refs = [empty_subtree; A];
 
             let child_items: [Option<Ref<T>>; A] = init_array(|i| {
-                self.children[i].as_ref().map(|item| item.item())
+                self.children[i]
+                    .as_ref()
+                    .and_then(|item| item.populated_item(height + 1))
             });
 
             let mut has_children = false;
@@ -58,8 +59,17 @@ where
             }
         }
 
-        // unwrapping is ok since we ensure it exists
+        // Unwrapping is safe because we ensure the item exists above.
         Ref::map(self.item.borrow(), |item| item.as_ref().unwrap())
+    }
+
+    // Unlike `item`, this does not allow lazy cache population to turn an
+    // item-less terminal node into an apparently populated leaf.
+    pub(crate) fn populated_item(&self, height: usize) -> Option<Ref<'_, T>> {
+        if height == H && !self.has_cached_item() {
+            return None;
+        }
+        Some(self.item(height))
     }
 
     pub(crate) fn child_location(height: usize, position: u64) -> (usize, u64) {
@@ -163,6 +173,22 @@ mod rkyv_impl {
     pub struct NodeResolver<T: Archive, const H: usize, const A: usize> {
         item: Resolver<Option<T>>,
         children: Resolver<[Option<Box<Node<T, H, A>>>; A]>,
+    }
+
+    impl<T: Archive, const H: usize, const A: usize> ArchivedNode<T, H, A> {
+        pub(crate) fn has_item(&self) -> bool {
+            self.item.is_some()
+        }
+
+        pub(crate) fn child(&self, index: usize) -> Option<&Self> {
+            self.children.get(index)?.as_deref()
+        }
+
+        pub(crate) fn has_children(&self) -> bool {
+            self.children
+                .iter()
+                .any(rkyv::option::ArchivedOption::is_some)
+        }
     }
 
     impl<T, const H: usize, const A: usize> Archive for Node<T, H, A>

--- a/dusk-merkle/src/opening.rs
+++ b/dusk-merkle/src/opening.rs
@@ -139,7 +139,7 @@ where
             positions,
         };
         fill_opening(&mut opening, &tree.root, 0, position)?;
-        opening.root = tree.root.item().clone();
+        opening.root = tree.root.item(0).clone();
 
         Some(opening)
     }
@@ -302,7 +302,9 @@ where
 
     for i in 0..A {
         if let Some(child) = &node.children[i] {
-            opening.branch[height][i] = child.item().clone();
+            if let Some(item) = child.populated_item(height + 1) {
+                opening.branch[height][i] = item.clone();
+            }
         }
     }
     opening.positions[height] = child_index;

--- a/dusk-merkle/src/tree.rs
+++ b/dusk-merkle/src/tree.rs
@@ -13,8 +13,7 @@ use crate::{Aggregate, Node, Opening, Walk, capacity};
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(
     feature = "rkyv-impl",
-    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
-    archive_attr(derive(bytecheck::CheckBytes))
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
 )]
 pub struct Tree<T, const H: usize, const A: usize> {
     pub(crate) root: Node<T, H, A>,
@@ -106,7 +105,7 @@ where
 
     /// Get the root of the merkle tree.
     pub fn root(&self) -> Ref<'_, T> {
-        self.root.item()
+        self.root.item(0)
     }
 
     /// Returns the root of the smallest sub-tree that holds all the leaves.
@@ -130,7 +129,7 @@ where
                     // current height as the root and height of the smallest
                     // subtree
                     else {
-                        return (smallest_node.item(), height);
+                        return (smallest_node.item(H - height), height);
                     }
                 }
             }
@@ -159,6 +158,196 @@ where
     #[must_use]
     pub const fn capacity(&self) -> u64 {
         capacity(A as u64, H)
+    }
+}
+
+// Extend rkyv's structural byte checks with tree invariants without changing
+// the archived representation.
+#[cfg(feature = "rkyv-impl")]
+mod rkyv_impl {
+    use alloc::boxed::Box;
+    use alloc::collections::BTreeSet;
+    use core::{fmt, ptr};
+
+    use bytecheck::{CheckBytes, Error, StructCheckError};
+    use rkyv::{Archive, Archived};
+
+    use super::ArchivedTree;
+    use crate::Node;
+
+    #[derive(Debug)]
+    struct ArchiveInvariantError(&'static str);
+
+    impl fmt::Display for ArchiveInvariantError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str(self.0)
+        }
+    }
+
+    impl core::error::Error for ArchiveInvariantError {}
+
+    fn field_error(
+        field_name: &'static str,
+        error: impl Error,
+    ) -> StructCheckError {
+        StructCheckError {
+            field_name,
+            inner: Box::new(error),
+        }
+    }
+
+    fn invariant_error(message: &'static str) -> StructCheckError {
+        field_error("positions", ArchiveInvariantError(message))
+    }
+
+    fn checked_capacity<const H: usize, const A: usize>() -> Option<u64> {
+        if H == 0 || A == 0 {
+            return None;
+        }
+
+        let arity = u64::try_from(A).ok()?;
+        let height = u32::try_from(H).ok()?;
+        arity.checked_pow(height)
+    }
+
+    fn validate_node<T, I, const H: usize, const A: usize>(
+        node: &Archived<Node<T, H, A>>,
+        height: usize,
+        position: u64,
+        capacity: u64,
+        positions: &mut I,
+    ) -> Result<(), ArchiveInvariantError>
+    where
+        T: Archive,
+        I: Iterator<Item = u64>,
+    {
+        if height == H {
+            if node.has_children() {
+                return Err(ArchiveInvariantError(
+                    "an archived node extends below the tree height",
+                ));
+            }
+            if !node.has_item() {
+                return Err(ArchiveInvariantError(
+                    "an archived leaf has no item",
+                ));
+            }
+            return match positions.next() {
+                Some(expected) if expected == position => Ok(()),
+                _ => Err(ArchiveInvariantError(
+                    "archived leaves and recorded positions do not match",
+                )),
+            };
+        }
+
+        let child_capacity = capacity
+            / u64::try_from(A).map_err(|_| {
+                ArchiveInvariantError("the archived tree arity exceeds u64")
+            })?;
+        let mut has_children = false;
+        for index in 0..A {
+            if let Some(child) = node.child(index) {
+                has_children = true;
+                let offset = u64::try_from(index)
+                    .ok()
+                    .and_then(|index| index.checked_mul(child_capacity))
+                    .and_then(|offset| position.checked_add(offset))
+                    .ok_or(ArchiveInvariantError(
+                        "an archived path exceeds the tree capacity",
+                    ))?;
+                validate_node(
+                    child,
+                    height + 1,
+                    offset,
+                    child_capacity,
+                    positions,
+                )?;
+            }
+        }
+
+        if !has_children && height != 0 {
+            return Err(ArchiveInvariantError(
+                "an archived path has no populated leaf",
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn validate_archive<T, const H: usize, const A: usize>(
+        tree: &ArchivedTree<T, H, A>,
+    ) -> Result<(), StructCheckError>
+    where
+        T: Archive,
+    {
+        let capacity = checked_capacity::<H, A>().ok_or_else(|| {
+            invariant_error(
+                "tree height and arity must be nonzero and fit in u64 capacity",
+            )
+        })?;
+
+        if tree.positions.iter().any(|position| *position >= capacity) {
+            return Err(invariant_error(
+                "an archived position is outside the tree capacity",
+            ));
+        }
+
+        let mut positions = tree.positions.iter().copied();
+        validate_node(&tree.root, 0, 0, capacity, &mut positions)
+            .map_err(|error| field_error("root", error))?;
+        if positions.next().is_some() {
+            return Err(invariant_error(
+                "archived leaves and recorded positions do not match",
+            ));
+        }
+
+        Ok(())
+    }
+
+    impl<C, T, const H: usize, const A: usize> CheckBytes<C>
+        for ArchivedTree<T, H, A>
+    where
+        C: ?Sized,
+        T: Archive,
+        Archived<Node<T, H, A>>: CheckBytes<C>,
+        Archived<BTreeSet<u64>>: CheckBytes<C>,
+    {
+        // Keep the derive-generated error type for API compatibility while
+        // extending the field checks with semantic tree validation.
+        type Error = StructCheckError;
+
+        unsafe fn check_bytes<'a>(
+            value: *const Self,
+            context: &mut C,
+        ) -> Result<&'a Self, Self::Error> {
+            // SAFETY: The caller guarantees that `value` is aligned and points
+            // to enough bytes for `Self`; each field validator checks its own
+            // archived representation and referenced data.
+            unsafe {
+                <Archived<Node<T, H, A>> as CheckBytes<C>>::check_bytes(
+                    ptr::addr_of!((*value).root),
+                    context,
+                )
+            }
+            .map_err(|error| field_error("root", error))?;
+
+            // SAFETY: This is the second field of the same caller-validated
+            // `ArchivedTree` allocation. Its validator checks all B-tree data
+            // before semantic validation reads it.
+            unsafe {
+                <Archived<BTreeSet<u64>> as CheckBytes<C>>::check_bytes(
+                    ptr::addr_of!((*value).positions),
+                    context,
+                )
+            }
+            .map_err(|error| field_error("positions", error))?;
+
+            // SAFETY: Both fields and all referenced archived data have been
+            // structurally validated above.
+            let tree = unsafe { &*value };
+            validate_archive(tree)?;
+            Ok(tree)
+        }
     }
 }
 
@@ -414,24 +603,143 @@ mod tests {
 
     #[cfg(feature = "rkyv-impl")]
     mod rkyv_impl {
-        use super::SumTree;
+        extern crate std;
+
+        use alloc::boxed::Box;
+        use alloc::vec::Vec;
+        use std::panic::{AssertUnwindSafe, catch_unwind};
+
+        use super::{A, H, SumTree};
+        use crate::{Aggregate, Node};
+
+        const POSITION: u64 = 5;
+
+        fn archive(tree: &SumTree) -> Vec<u8> {
+            rkyv::to_bytes::<_, 128>(tree)
+                .expect("Archiving a tree should succeed")
+                .to_vec()
+        }
+
+        fn assert_rejected_without_unwind(case: &str, tree: &SumTree) {
+            let tree_bytes = archive(tree);
+            let result = catch_unwind(AssertUnwindSafe(|| {
+                rkyv::from_bytes::<SumTree>(&tree_bytes)
+            }));
+
+            match result {
+                Ok(Err(_)) => {}
+                Ok(Ok(_)) => panic!("{case}: malformed archive was accepted"),
+                Err(_) => panic!("{case}: archive rejection unwound"),
+            }
+        }
+
+        fn populated_tree() -> SumTree {
+            let mut tree = SumTree::new();
+            tree.insert(POSITION, 42);
+            tree
+        }
+
+        fn replace_leaf_with_itemless_node(
+            node: &mut Node<u8, H, A>,
+            height: usize,
+            position: u64,
+        ) {
+            let (child_index, child_position) =
+                Node::<u8, H, A>::child_location(height, position);
+            if height + 1 == H {
+                node.children[child_index] = Some(Box::new(Node::new()));
+                return;
+            }
+
+            let child = node.children[child_index]
+                .as_mut()
+                .expect("The inserted item must populate every path node");
+            replace_leaf_with_itemless_node(child, height + 1, child_position);
+        }
+
+        fn tree_with_itemless_leaf() -> SumTree {
+            let mut tree = populated_tree();
+            replace_leaf_with_itemless_node(&mut tree.root, 0, POSITION);
+            tree
+        }
 
         #[test]
-        fn serde() {
-            let mut tree = SumTree::new();
+        fn valid_tree_round_trip_and_operations() {
+            let tree = populated_tree();
+            let mut decoded = rkyv::from_bytes::<SumTree>(&archive(&tree))
+                .expect("Deserializing a valid tree should succeed");
 
-            tree.insert(5, 42);
-            tree.insert(6, 42);
-            tree.insert(5, 42);
+            assert_eq!(tree, decoded);
+            assert!(
+                decoded
+                    .opening(POSITION)
+                    .is_some_and(|opening| opening.verify(42))
+            );
+            assert_eq!(decoded.remove(POSITION), Some(42));
 
-            let tree_bytes = rkyv::to_bytes::<_, 128>(&tree)
-                .expect("Archiving a tree should succeed")
-                .to_vec();
+            let round_trip = rkyv::from_bytes::<SumTree>(&archive(&decoded))
+                .expect("A valid modified tree should still round-trip");
+            assert_eq!(decoded, round_trip);
+        }
 
-            let archived_tree = rkyv::from_bytes::<SumTree>(&tree_bytes)
-                .expect("Deserializing a tree should succeed");
+        #[test]
+        fn itemless_archived_leaf_is_rejected() {
+            assert_rejected_without_unwind(
+                "item-less leaf",
+                &tree_with_itemless_leaf(),
+            );
+        }
 
-            assert_eq!(tree, archived_tree);
+        #[test]
+        fn itemless_archived_leaf_is_rejected_after_cache_warming() {
+            let tree = tree_with_itemless_leaf();
+
+            assert_eq!(*tree.root(), u8::EMPTY_SUBTREE);
+            let (smallest, height) = tree.smallest_subtree();
+            assert_eq!(*smallest, u8::EMPTY_SUBTREE);
+            assert_eq!(height, 1);
+            drop(smallest);
+            assert!(tree.opening(POSITION).is_none());
+            assert!(tree.walk(|_| true).next().is_none());
+
+            assert_rejected_without_unwind("warmed item-less leaf", &tree);
+        }
+
+        #[test]
+        fn inconsistent_archives_are_rejected() {
+            let mut missing_root = populated_tree();
+            let (child_index, _) =
+                Node::<u8, H, A>::child_location(0, POSITION);
+            missing_root.root.children[child_index] = None;
+
+            let mut missing_mid = populated_tree();
+            let (child_index, child_position) =
+                Node::<u8, H, A>::child_location(0, POSITION);
+            let child = missing_mid.root.children[child_index]
+                .as_mut()
+                .expect("The inserted item must populate the root child");
+            let (child_index, _) =
+                Node::<u8, H, A>::child_location(1, child_position);
+            child.children[child_index] = None;
+
+            let mut out_of_capacity = populated_tree();
+            out_of_capacity.positions.insert(1 << 34);
+
+            let mut unrecorded = populated_tree();
+            unrecorded.positions.remove(&POSITION);
+
+            let mut dangling = SumTree::new();
+            dangling.root.children[0] = Some(Box::new(Node::new()));
+
+            for (case, tree) in [
+                ("missing root path", missing_root),
+                ("missing mid-path", missing_mid),
+                ("out-of-capacity position", out_of_capacity),
+                ("unrecorded leaf", unrecorded),
+                ("path without a leaf", dangling),
+            ] {
+                assert_rejected_without_unwind(case, &tree);
+            }
         }
     }
 }

--- a/dusk-merkle/src/tree.rs
+++ b/dusk-merkle/src/tree.rs
@@ -207,6 +207,9 @@ mod rkyv_impl {
         arity.checked_pow(height)
     }
 
+    // The linear leaf-position match relies on `BTreeSet` iteration yielding
+    // ascending positions and index-ordered DFS visiting leaves in the same
+    // order.
     fn validate_node<T, I, const H: usize, const A: usize>(
         node: &Archived<Node<T, H, A>>,
         height: usize,
@@ -320,6 +323,9 @@ mod rkyv_impl {
         Ok(())
     }
 
+    // Internal aggregate caches are deliberately not validated here. The
+    // corresponding `Deserialize` impl must discard them so that accepted
+    // archives produce aggregates derived from their leaves.
     impl<C, T, const H: usize, const A: usize> CheckBytes<C>
         for ArchivedTree<T, H, A>
     where
@@ -622,11 +628,12 @@ mod tests {
         extern crate std;
 
         use alloc::boxed::Box;
+        use alloc::string::ToString;
         use alloc::vec::Vec;
         use std::panic::{AssertUnwindSafe, catch_unwind};
 
         use super::{A, H, SumTree};
-        use crate::{Aggregate, Node};
+        use crate::{Aggregate, Node, Opening};
 
         const POSITION: u64 = 5;
 
@@ -636,14 +643,21 @@ mod tests {
                 .to_vec()
         }
 
-        fn assert_rejected_without_unwind(case: &str, tree: &SumTree) {
+        fn assert_rejected_without_unwind(
+            case: &str,
+            tree: &SumTree,
+            expected_error: &str,
+        ) {
             let tree_bytes = archive(tree);
             let result = catch_unwind(AssertUnwindSafe(|| {
                 rkyv::from_bytes::<SumTree>(&tree_bytes)
             }));
 
             match result {
-                Ok(Err(_)) => {}
+                Ok(Err(error)) => assert!(
+                    error.to_string().contains(expected_error),
+                    "{case}: expected error containing {expected_error:?}, got {error}"
+                ),
                 Ok(Ok(_)) => panic!("{case}: malformed archive was accepted"),
                 Err(_) => panic!("{case}: archive rejection unwound"),
             }
@@ -741,7 +755,7 @@ mod tests {
         }
 
         type OperationResults =
-            (u8, Option<crate::Opening<u8, H, A>>, (u8, usize), Vec<u8>);
+            (u8, Option<Opening<u8, H, A>>, (u8, usize), Vec<u8>);
 
         fn operation_results_without_unwind(
             case: &str,
@@ -854,16 +868,30 @@ mod tests {
         }
 
         #[test]
+        fn archived_node_below_tree_height_is_rejected() {
+            let mut tree = populated_tree();
+            let leaf = node_at_height_mut(&mut tree, H, POSITION);
+            leaf.children[0] = Some(Box::new(Node::new()));
+
+            assert_rejected_without_unwind(
+                "node below tree height",
+                &tree,
+                "an archived node extends below the tree height",
+            );
+        }
+
+        #[test]
         fn itemless_archived_leaf_is_rejected() {
             assert_rejected_without_unwind(
                 "item-less leaf",
                 &tree_with_itemless_leaf(),
+                "an archived leaf has no item",
             );
         }
 
         #[test]
         fn itemless_archived_leaf_is_rejected_after_cache_warming() {
-            let tree = tree_with_itemless_leaf();
+            let mut tree = tree_with_itemless_leaf();
 
             assert_eq!(*tree.root(), u8::EMPTY_SUBTREE);
             let (smallest, height) = tree.smallest_subtree();
@@ -872,8 +900,31 @@ mod tests {
             drop(smallest);
             assert!(tree.opening(POSITION).is_none());
             assert!(tree.walk(|_| true).next().is_none());
+            assert!(tree.remove(POSITION).is_none());
 
-            assert_rejected_without_unwind("warmed item-less leaf", &tree);
+            assert_rejected_without_unwind(
+                "warmed item-less leaf",
+                &tree,
+                "an archived leaf has no item",
+            );
+        }
+
+        #[test]
+        fn itemless_sibling_is_rejected_after_opening_cache_warming() {
+            let mut tree = valid_two_leaf_tree();
+            replace_leaf_with_itemless_node(&mut tree.root, 0, POSITION);
+
+            let opening = tree
+                .opening(4)
+                .expect("the populated sibling must have an opening");
+            assert!(opening.verify(20));
+            assert!(tree.remove(POSITION).is_none());
+
+            assert_rejected_without_unwind(
+                "item-less sibling warmed by opening",
+                &tree,
+                "an archived leaf has no item",
+            );
         }
 
         #[test]
@@ -899,17 +950,46 @@ mod tests {
             let mut unrecorded = populated_tree();
             unrecorded.positions.remove(&POSITION);
 
+            let mut wrong_position = populated_tree();
+            wrong_position.positions.remove(&POSITION);
+            wrong_position.positions.insert(4);
+
             let mut dangling = SumTree::new();
             dangling.root.children[0] = Some(Box::new(Node::new()));
 
-            for (case, tree) in [
-                ("missing root path", missing_root),
-                ("missing mid-path", missing_mid),
-                ("out-of-capacity position", out_of_capacity),
-                ("unrecorded leaf", unrecorded),
-                ("path without a leaf", dangling),
+            for (case, tree, expected_error) in [
+                (
+                    "missing root path",
+                    missing_root,
+                    "archived leaves and recorded positions do not match",
+                ),
+                (
+                    "missing mid-path",
+                    missing_mid,
+                    "an archived path has no populated leaf",
+                ),
+                (
+                    "out-of-capacity position",
+                    out_of_capacity,
+                    "an archived position is outside the tree capacity",
+                ),
+                (
+                    "unrecorded leaf",
+                    unrecorded,
+                    "archived leaves and recorded positions do not match",
+                ),
+                (
+                    "wrong recorded position",
+                    wrong_position,
+                    "archived leaves and recorded positions do not match",
+                ),
+                (
+                    "path without a leaf",
+                    dangling,
+                    "an archived path has no populated leaf",
+                ),
             ] {
-                assert_rejected_without_unwind(case, &tree);
+                assert_rejected_without_unwind(case, &tree, expected_error);
             }
         }
     }

--- a/dusk-merkle/src/tree.rs
+++ b/dusk-merkle/src/tree.rs
@@ -11,10 +11,7 @@ use crate::{Aggregate, Node, Opening, Walk, capacity};
 
 /// A sparse Merkle tree.
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "rkyv-impl",
-    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
-)]
+#[cfg_attr(feature = "rkyv-impl", derive(rkyv::Archive, rkyv::Serialize))]
 pub struct Tree<T, const H: usize, const A: usize> {
     pub(crate) root: Node<T, H, A>,
     positions: BTreeSet<u64>,
@@ -170,9 +167,9 @@ mod rkyv_impl {
     use core::{fmt, ptr};
 
     use bytecheck::{CheckBytes, Error, StructCheckError};
-    use rkyv::{Archive, Archived};
+    use rkyv::{Archive, Archived, Deserialize, Fallible};
 
-    use super::ArchivedTree;
+    use super::{ArchivedTree, Tree};
     use crate::Node;
 
     #[derive(Debug)]
@@ -272,6 +269,25 @@ mod rkyv_impl {
         }
 
         Ok(())
+    }
+
+    impl<D, T, const H: usize, const A: usize> Deserialize<Tree<T, H, A>, D>
+        for ArchivedTree<T, H, A>
+    where
+        D: Fallible + ?Sized,
+        T: Archive,
+        Archived<Node<T, H, A>>: Deserialize<Node<T, H, A>, D>,
+        Archived<BTreeSet<u64>>: Deserialize<BTreeSet<u64>, D>,
+    {
+        fn deserialize(
+            &self,
+            deserializer: &mut D,
+        ) -> Result<Tree<T, H, A>, D::Error> {
+            let root = self.root.deserialize(deserializer)?;
+            root.clear_internal_caches(0);
+            let positions = self.positions.deserialize(deserializer)?;
+            Ok(Tree { root, positions })
+        }
     }
 
     fn validate_archive<T, const H: usize, const A: usize>(
@@ -639,6 +655,41 @@ mod tests {
             tree
         }
 
+        fn decode_without_unwind(case: &str, tree: &SumTree) -> SumTree {
+            let tree_bytes = archive(tree);
+            let result = catch_unwind(AssertUnwindSafe(|| {
+                rkyv::from_bytes::<SumTree>(&tree_bytes)
+            }));
+
+            match result {
+                Ok(Ok(tree)) => tree,
+                Ok(Err(error)) => {
+                    panic!(
+                        "{case}: structurally valid archive was rejected: {error}"
+                    )
+                }
+                Err(_) => panic!("{case}: checked deserialization unwound"),
+            }
+        }
+
+        fn node_at_height_mut(
+            tree: &mut SumTree,
+            target_height: usize,
+            position: u64,
+        ) -> &mut Node<u8, H, A> {
+            let mut node = &mut tree.root;
+            let mut child_position = position;
+            for height in 0..target_height {
+                let (child_index, next_position) =
+                    Node::<u8, H, A>::child_location(height, child_position);
+                node = node.children[child_index]
+                    .as_mut()
+                    .expect("The inserted items must populate the path");
+                child_position = next_position;
+            }
+            node
+        }
+
         fn replace_leaf_with_itemless_node(
             node: &mut Node<u8, H, A>,
             height: usize,
@@ -680,6 +731,126 @@ mod tests {
             let round_trip = rkyv::from_bytes::<SumTree>(&archive(&decoded))
                 .expect("A valid modified tree should still round-trip");
             assert_eq!(decoded, round_trip);
+        }
+
+        fn valid_two_leaf_tree() -> SumTree {
+            let mut tree = SumTree::new();
+            tree.insert(4, 20);
+            tree.insert(5, 22);
+            tree
+        }
+
+        type OperationResults =
+            (u8, Option<crate::Opening<u8, H, A>>, (u8, usize), Vec<u8>);
+
+        fn operation_results_without_unwind(
+            case: &str,
+            tree: &SumTree,
+            position: u64,
+        ) -> OperationResults {
+            catch_unwind(AssertUnwindSafe(|| {
+                let root = *tree.root();
+                let opening = tree.opening(position);
+                let (smallest, height) = tree.smallest_subtree();
+                let smallest = (*smallest, height);
+                let walk = tree
+                    .walk(|item| *item <= 42)
+                    .map(|item| *item)
+                    .collect::<Vec<_>>();
+                (root, opening, smallest, walk)
+            }))
+            .unwrap_or_else(|_| {
+                panic!("{case}: decoded tree operation unwound")
+            })
+        }
+
+        fn assert_decodes_like(
+            case: &str,
+            archived: &SumTree,
+            expected: &SumTree,
+            position: u64,
+        ) {
+            let expected = operation_results_without_unwind(
+                "canonical tree",
+                expected,
+                position,
+            );
+            let decoded = decode_without_unwind(case, archived);
+            assert!(
+                !decoded.root.has_cached_item(),
+                "{case}: the decoded root cache must be cold"
+            );
+            assert_eq!(
+                operation_results_without_unwind(case, &decoded, position),
+                expected,
+                "{case}: decoded operations must use aggregates derived from leaves"
+            );
+        }
+
+        #[test]
+        fn noncanonical_empty_root_cache_is_discarded() {
+            let expected = SumTree::new();
+            let archived = SumTree::new();
+            archived.root.replace_cached_item(Some(99));
+
+            assert_decodes_like("empty root cache", &archived, &expected, 0);
+        }
+
+        #[test]
+        fn noncanonical_populated_root_cache_is_discarded() {
+            let expected = populated_tree();
+            let archived = expected.clone();
+            archived.root.replace_cached_item(Some(99));
+
+            assert_decodes_like(
+                "populated root cache",
+                &archived,
+                &expected,
+                POSITION,
+            );
+        }
+
+        #[test]
+        fn noncanonical_intermediate_cache_is_discarded() {
+            let expected = valid_two_leaf_tree();
+            let mut archived = expected.clone();
+            node_at_height_mut(&mut archived, H - 1, 4)
+                .replace_cached_item(Some(99));
+            archived.root.replace_cached_item(None);
+
+            assert_decodes_like(
+                "intermediate cache with cold root",
+                &archived,
+                &expected,
+                4,
+            );
+        }
+
+        #[test]
+        fn valid_cold_and_warmed_archives_preserve_operations() {
+            let cold = valid_two_leaf_tree();
+            let warmed = cold.clone();
+            let expected =
+                operation_results_without_unwind("valid tree", &warmed, 4);
+
+            assert_eq!(expected.0, 42);
+            assert!(expected.1.is_some_and(|opening| {
+                *opening.root() == 42 && opening.verify(20)
+            }));
+            assert_eq!(expected.2, (42, 1));
+            assert_eq!(expected.3, [20, 22]);
+
+            for (case, tree) in [
+                ("valid cold archive", &cold),
+                ("valid warmed archive", &warmed),
+            ] {
+                let decoded = decode_without_unwind(case, tree);
+                assert!(!decoded.root.has_cached_item());
+                assert_eq!(
+                    operation_results_without_unwind(case, &decoded, 4),
+                    expected
+                );
+            }
         }
 
         #[test]

--- a/dusk-merkle/src/walk.rs
+++ b/dusk-merkle/src/walk.rs
@@ -50,7 +50,9 @@ where
             for i in *index..A {
                 *index = i + 1;
                 if let Some(leaf) = &node.children[i] {
-                    let leaf = leaf.item();
+                    let Some(leaf) = leaf.populated_item(h + 1) else {
+                        continue;
+                    };
                     if (self.walker)(&*leaf) {
                         return Some(leaf);
                     }
@@ -71,7 +73,7 @@ where
                 self.indices[h] = i;
                 if let Some(child) = &node.children[i] {
                     let child = child.as_ref();
-                    if (self.walker)(&*child.item()) {
+                    if (self.walker)(&*child.item(h + 1)) {
                         self.path[h] = Some(child);
                         break;
                     }
@@ -94,7 +96,7 @@ where
 
                 if let Some(child) = &node.children[i] {
                     let child = child.as_ref();
-                    if (self.walker)(&*child.item()) {
+                    if (self.walker)(&*child.item(h + 1)) {
                         self.path[h] = Some(child);
                         if let Some(item) = self.advance(child, h + 1) {
                             return Some(item);

--- a/poseidon-merkle/CHANGELOG.md
+++ b/poseidon-merkle/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Benchmark cold decoded-tree root recomputation against warmed dirty paths [#125]
+- Restore compilation of the PLONK benchmark
+
 ### Changed
 
 - Update `dusk-plonk` to `v0.22.0-rc.0`
@@ -84,6 +89,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add poseidon-merkle crate [#58]
 
 <!-- ISSUES -->
+[#125]: https://github.com/dusk-network/merkle/issues/125
 [#85]: https://github.com/dusk-network/merkle/issues/85
 [#58]: https://github.com/dusk-network/merkle/issues/58
 

--- a/poseidon-merkle/README.md
+++ b/poseidon-merkle/README.md
@@ -39,7 +39,19 @@ and additional benchmarks for the opening proof generation with PLONK
 cargo bench --features zk
 ```
 
-This requires a nightly toolchain.
+The first-root cost after checked RKYV deserialization can be compared with a
+warmed tree after one or four leaf updates using:
+```shell
+cargo bench -p poseidon-merkle --bench poseidon \
+  --features rkyv-impl,size_32 -- poseidon_first_root
+```
+The benchmark times `root()` separately from decode and also reports the
+combined decode-and-first-root cost. As with `dusk-merkle`, checked
+deserialization discards archived internal aggregates because their relation to
+the leaves cannot be established by structural validation. The first aggregate
+read rebuilds those caches from leaf values.
+
+The PLONK benchmarks require a nightly toolchain.
 
 ## License
 

--- a/poseidon-merkle/benches/poseidon.rs
+++ b/poseidon-merkle/benches/poseidon.rs
@@ -4,6 +4,8 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+#[cfg(feature = "rkyv-impl")]
+use criterion::BenchmarkId;
 use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use dusk_bls12_381::BlsScalar;
 use dusk_poseidon::{Domain, Hash};
@@ -35,5 +37,199 @@ fn bench_poseidon(c: &mut Criterion) {
         })
     });
 }
+
+#[cfg(feature = "rkyv-impl")]
+#[derive(Clone, Copy)]
+enum Occupancy {
+    Dense,
+    Sparse,
+}
+
+#[cfg(feature = "rkyv-impl")]
+#[derive(Clone, Copy)]
+struct Scenario {
+    name: &'static str,
+    leaves: u64,
+    occupancy: Occupancy,
+}
+
+#[cfg(feature = "rkyv-impl")]
+const FIRST_ROOT_SCENARIOS: &[Scenario] = &[
+    Scenario {
+        name: "sparse_64",
+        leaves: 64,
+        occupancy: Occupancy::Sparse,
+    },
+    Scenario {
+        name: "sparse_512",
+        leaves: 512,
+        occupancy: Occupancy::Sparse,
+    },
+    Scenario {
+        name: "dense_512",
+        leaves: 512,
+        occupancy: Occupancy::Dense,
+    },
+    Scenario {
+        name: "dense_4096",
+        leaves: 4096,
+        occupancy: Occupancy::Dense,
+    },
+];
+
+#[cfg(feature = "rkyv-impl")]
+fn scenario_position(scenario: Scenario, index: u64) -> u64 {
+    match scenario.occupancy {
+        Occupancy::Dense => index,
+        // The odd multiplier is a permutation modulo the power-of-two tree
+        // capacity, so positions are deterministic, unique, and spread out.
+        Occupancy::Sparse => {
+            index.wrapping_mul(0x2_78dd_e6e5) & ((1u64 << 34) - 1)
+        }
+    }
+}
+
+#[cfg(feature = "rkyv-impl")]
+fn scenario_item(position: u64, generation: u64) -> PoseidonItem {
+    let value = position
+        .wrapping_add(generation.wrapping_mul(0x9e37_79b9))
+        .wrapping_add(1);
+    PoseidonItem::new(BlsScalar::from(value), ())
+}
+
+#[cfg(feature = "rkyv-impl")]
+fn scenario_tree(scenario: Scenario) -> PoseidonTree {
+    let mut tree = PoseidonTree::new();
+    for index in 0..scenario.leaves {
+        let position = scenario_position(scenario, index);
+        tree.insert(position, scenario_item(position, 0));
+    }
+    assert_eq!(
+        tree.len(),
+        scenario.leaves,
+        "scenario positions must be unique"
+    );
+    tree
+}
+
+#[cfg(feature = "rkyv-impl")]
+fn update_tree(
+    tree: &mut PoseidonTree,
+    scenario: Scenario,
+    update_count: u64,
+    generation: u64,
+) {
+    let stride = scenario.leaves / update_count;
+    for update in 0..update_count {
+        let index = update * stride;
+        let position = scenario_position(scenario, index);
+        tree.insert(position, scenario_item(position, generation));
+    }
+}
+
+#[cfg(feature = "rkyv-impl")]
+fn bench_poseidon_first_root(c: &mut Criterion) {
+    use std::time::{Duration, Instant};
+
+    let mut group = c.benchmark_group("poseidon_first_root");
+    group
+        .sample_size(10)
+        .warm_up_time(Duration::from_secs(1))
+        .measurement_time(Duration::from_secs(4));
+
+    for &scenario in FIRST_ROOT_SCENARIOS {
+        let base = scenario_tree(scenario);
+        let warmed_root = *base.root();
+
+        let mut dirty = base.clone();
+        update_tree(&mut dirty, scenario, 1, 1);
+        let dirty_root = *dirty.root();
+        assert_ne!(warmed_root, dirty_root, "the update must change the root");
+        let archive = rkyv::to_bytes::<_, 4096>(&dirty)
+            .expect("scenario tree archiving must succeed");
+        let decoded = rkyv::from_bytes::<PoseidonTree>(&archive)
+            .expect("scenario tree checked deserialization must succeed");
+        let decoded_root = *decoded.root();
+        assert_eq!(
+            decoded_root, dirty_root,
+            "both paths must compute the same root"
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new(scenario.name, "cold_decoded"),
+            &scenario,
+            |b, _| {
+                b.iter_custom(|iterations| {
+                    let mut measured = Duration::ZERO;
+                    for _ in 0..iterations {
+                        // Checked decode is setup: every timed root receives a
+                        // fresh tree whose internal caches were discarded.
+                        let tree = rkyv::from_bytes::<PoseidonTree>(&archive)
+                            .expect("checked deserialization must succeed");
+                        let start = Instant::now();
+                        black_box(*tree.root());
+                        measured += start.elapsed();
+                    }
+                    measured
+                });
+            },
+        );
+
+        for update_count in [1, 4] {
+            group.bench_with_input(
+                BenchmarkId::new(
+                    scenario.name,
+                    format!("warm_dirty_{update_count}"),
+                ),
+                &scenario,
+                |b, &scenario| {
+                    let mut tree = scenario_tree(scenario);
+                    black_box(*tree.root());
+                    let mut generation = 1;
+                    b.iter_custom(|iterations| {
+                        let mut measured = Duration::ZERO;
+                        for _ in 0..iterations {
+                            // Updating is setup. The timer covers only root
+                            // recomputation along the newly dirtied paths.
+                            update_tree(
+                                &mut tree,
+                                scenario,
+                                update_count,
+                                generation,
+                            );
+                            generation += 1;
+                            let start = Instant::now();
+                            black_box(*tree.root());
+                            measured += start.elapsed();
+                        }
+                        measured
+                    });
+                },
+            );
+        }
+
+        group.bench_with_input(
+            BenchmarkId::new(scenario.name, "decode_and_first_root"),
+            &scenario,
+            |b, _| {
+                b.iter_custom(|iterations| {
+                    let mut measured = Duration::ZERO;
+                    for _ in 0..iterations {
+                        let start = Instant::now();
+                        let tree = rkyv::from_bytes::<PoseidonTree>(&archive)
+                            .expect("checked deserialization must succeed");
+                        black_box(*tree.root());
+                        measured += start.elapsed();
+                    }
+                    measured
+                });
+            },
+        );
+    }
+}
+
+#[cfg(feature = "rkyv-impl")]
+criterion_group!(benches, bench_poseidon, bench_poseidon_first_root);
+#[cfg(not(feature = "rkyv-impl"))]
 criterion_group!(benches, bench_poseidon);
 criterion_main!(benches);

--- a/poseidon-merkle/benches/zk.rs
+++ b/poseidon-merkle/benches/zk.rs
@@ -8,6 +8,7 @@
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use dusk_plonk::prelude::*;
+use dusk_poseidon::{Domain, Hash};
 use poseidon_merkle::zk::opening_gadget;
 use poseidon_merkle::{Item, Opening, Tree};
 use rand::rngs::StdRng;
@@ -16,17 +17,16 @@ use rand::{RngCore, SeedableRng};
 // set max circuit size to 2^13 gates
 const CAPACITY: usize = 16;
 
-// set height and arity of the poseidon merkle tree
+// set height of the poseidon merkle tree
 const HEIGHT: usize = 17;
-const ARITY: usize = 4;
 
-type PoseidonTree = Tree<(), HEIGHT, ARITY>;
+type PoseidonTree = Tree<(), HEIGHT>;
 type PoseidonItem = Item<()>;
 
 // Create a circuit for the opening
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 struct OpeningCircuit {
-    opening: Opening<(), HEIGHT, ARITY>,
+    opening: Opening<(), HEIGHT>,
     leaf: PoseidonItem,
 }
 
@@ -48,10 +48,7 @@ impl Default for OpeningCircuit {
 
 impl OpeningCircuit {
     /// Create a new OpeningCircuit
-    pub fn new(
-        opening: Opening<(), HEIGHT, ARITY>,
-        leaf: PoseidonItem,
-    ) -> Self {
+    pub fn new(opening: Opening<(), HEIGHT>, leaf: PoseidonItem) -> Self {
         Self { opening, leaf }
     }
 }
@@ -88,7 +85,7 @@ fn bench_zk(c: &mut Criterion) {
     for _ in 0..100 {
         let pos = rng.next_u64() % u32::MAX as u64;
         let leaf = PoseidonItem {
-            hash: dusk_poseidon::sponge::hash(&[pos.into()]),
+            hash: Hash::digest(Domain::Other, &[pos.into()])[0],
             data: (),
         };
         tree.insert(pos, leaf);
@@ -97,7 +94,7 @@ fn bench_zk(c: &mut Criterion) {
     // insert new leaf in the tree at random position to create opening
     let pos = rng.next_u64() % u32::MAX as u64;
     let leaf = PoseidonItem {
-        hash: dusk_poseidon::sponge::hash(&[pos.into()]),
+        hash: Hash::digest(Domain::Other, &[pos.into()])[0],
         data: (),
     };
     tree.insert(pos, leaf);


### PR DESCRIPTION
Refs #125

## Summary

- benchmark the first `root()` after checked RKYV deserialization separately from decoding
- compare cold decoded trees with warmed trees after one or four leaf updates
- cover Piecrust-shaped wasm32 and wasm64 Blake3 page trees and the Poseidon aggregate
- document why checked deserialization discards archived internal aggregates
- update the stale Poseidon ZK benchmark API so the full benchmark suite compiles

This is stacked on #120 because it measures the safe cache-discarding behavior introduced there. It does not change the archive layout, public API, or tree semantics. It no longer closes #125: the wasm64 measurements show that very large scattered contracts warrant further mitigation work.

## Measurements

Measured twice on an Intel Core Ultra 9 275HX under WSL2, using Criterion with 10 samples. The wasm64 runs were pinned to one core and peaked at about 1.03 GiB RSS because they materialize page hashes and Merkle nodes, not the corresponding contract-memory bytes.

For the Piecrust-shaped wasm32 Blake3 tree (`H = 8`, `A = 4`):

| Scenario | Cold first root | 1 dirty path | 4 dirty paths | Decode + first root |
| --- | ---: | ---: | ---: | ---: |
| sparse 64 | 35.6–36.0 µs | 0.88–0.92 µs | 2.99–3.19 µs | 52.0–52.1 µs |
| sparse 4,096 | 0.997–1.002 ms | 0.93–1.03 µs | 3.26–3.86 µs | 1.75–1.77 ms |
| dense 4,096 | 0.155–0.160 ms | 0.93–1.05 µs | 2.62–4.06 µs | 0.497–0.512 ms |
| dense 65,536 | 2.58–2.77 ms | 0.92–0.93 µs | 3.17–3.35 µs | 9.81–9.87 ms |

For the Piecrust-shaped wasm64 Blake3 tree (`H = 13`, `A = 4`):

| Populated memory | Distribution | Cold first root | Decode + first root |
| --- | --- | ---: | ---: |
| 10 GiB | dense | 8.68–9.06 ms | 34.1–37.6 ms |
| 10 GiB | scattered | 108–115 ms | 229–249 ms |
| 50 GiB | dense | 41.5–51.1 ms | 179–183 ms |
| 50 GiB | scattered | 386–454 ms | 0.876–1.02 s |
| 100 GiB | dense | 91.8–106 ms | 0.347–0.403 s |
| 100 GiB | scattered | 675–684 ms | 1.43–1.54 s |

For Poseidon (`H = 17`, `A = 4`):

| Scenario | Cold first root | 1 dirty path | 4 dirty paths | Decode + first root |
| --- | ---: | ---: | ---: | ---: |
| sparse 64 | 33.0–41.7 ms | 0.617–0.632 ms | 2.31–2.39 ms | 32.7–33.8 ms |
| sparse 512 | 233–244 ms | 0.607–0.641 ms | 2.27–2.33 ms | 235–244 ms |
| dense 512 | 6.57–6.77 ms | 0.611–0.630 ms | 0.966–1.016 ms | 6.62–6.89 ms |
| dense 4,096 | 49.3–50.9 ms | 0.610–0.628 ms | 1.15–1.21 ms | 49.9–52.5 ms |

Piecrust checked-deserializes contract page trees, applies dirty page updates, and reads the root during commit. The wasm32 cost is small, but the first post-load root for a very large wasm64 contract can be material, especially when populated pages are spread across the address space and share fewer internal nodes.

Eager reconstruction during deserialization only moves the same work earlier, while trusting archived aggregates would weaken #120. A safe mitigation therefore needs separate design work; the current leaf-derived behavior remains unchanged here.

## Validation

- both wasm64 benchmark runs completed successfully
- `make test`
- `make cq`
- `make no-std`
- checked RKYV tests for size 16, 32, and 64 in both crates
- `make check`
- `make doc`
- full workspace benchmark compilation
- Poseidon ZK tests

